### PR TITLE
fix: show toast notification when grouped export format is unavailable

### DIFF
--- a/app/evaluations/[id]/page.tsx
+++ b/app/evaluations/[id]/page.tsx
@@ -87,6 +87,11 @@ export default function EvaluationReport() {
 
       const data = await response.json();
 
+      if (data.success === false && data.error){
+        toast.error(data.error);
+        setExportFormat('row')
+      }
+
       // Backend may return the job directly or wrapped in a data property
       const foundJob = data.data || data;
 


### PR DESCRIPTION
Target Issue: #30 

**Summary:**

* Earlier, when the backend returned `success: false` with an error for the grouped format, the error was silently ignored.
* Now, a toast message is shown and the format selector is reverted to **Row**.

**Reason for the issue:**

* `question_id` is only created when a new dataset is uploaded.
* Older datasets do not have a `question_id`, which caused the grouped format to fail silently.

How it looks:

<img width="1486" height="785" alt="image" src="https://github.com/user-attachments/assets/e7e71501-6f28-4b43-897b-f352abee253c" />
