### PR TITLE
Config Listing Page: Show All Vector Stores in the Config Card Listing Page

### DIFF
--- a/app/components/ConfigCard.tsx
+++ b/app/components/ConfigCard.tsx
@@ -154,43 +154,59 @@ export default function ConfigCard({
                 ))}
 
                 {/* Vector Stores Section inside Tools */}
-                {latestVersion.vectorStoreIds && (
-                  <div className="mt-3 pt-2" style={{ borderTop: `1px solid ${colors.border}` }}>
-                    <button
-                      onClick={() => setShowVectorStores(!showVectorStores)}
-                      className="w-full flex items-center justify-between px-2 py-1 rounded-md transition-colors"
-                      style={{
-                        backgroundColor: colors.bg.primary,
-                      }}
-                    >
-                      <span style={{ color: colors.text.secondary, fontSize: '11px' }}>
-                        Vector Store IDs
-                      </span>
-                      <svg
-                        className={`w-3 h-3 transition-transform ${showVectorStores ? 'rotate-180' : ''}`}
-                        style={{ color: colors.text.secondary }}
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                      >
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                      </svg>
-                    </button>
-                    {showVectorStores && (
-                      <div
-                        className="mt-1 p-2 rounded-md break-all"
+                {(() => {
+                  // Collect all knowledge_base_ids from all tools
+                  const allVectorStoreIds = latestVersion.tools
+                    .flatMap(tool => tool.knowledge_base_ids || [])
+                    .filter(id => id);
+
+                  return allVectorStoreIds.length > 0 && (
+                    <div className="mt-3 pt-2" style={{ borderTop: `1px solid ${colors.border}` }}>
+                      <button
+                        onClick={() => setShowVectorStores(!showVectorStores)}
+                        className="w-full flex items-center justify-between px-2 py-1 rounded-md transition-colors"
                         style={{
                           backgroundColor: colors.bg.primary,
-                          color: colors.text.primary,
-                          fontFamily: 'monospace',
-                          fontSize: '10px',
                         }}
                       >
-                        {latestVersion.vectorStoreIds}
-                      </div>
-                    )}
-                  </div>
-                )}
+                        <span style={{ color: colors.text.secondary, fontSize: '11px' }}>
+                          Vector Store IDs ({allVectorStoreIds.length})
+                        </span>
+                        <svg
+                          className={`w-3 h-3 transition-transform ${showVectorStores ? 'rotate-180' : ''}`}
+                          style={{ color: colors.text.secondary }}
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                        </svg>
+                      </button>
+                      {showVectorStores && (
+                        <div
+                          className="mt-1 p-2 rounded-md space-y-1"
+                          style={{
+                            backgroundColor: colors.bg.primary,
+                            color: colors.text.primary,
+                          }}
+                        >
+                          {allVectorStoreIds.map((id, idx) => (
+                            <div
+                              key={idx}
+                              className="break-all"
+                              style={{
+                                fontFamily: 'monospace',
+                                fontSize: '10px',
+                              }}
+                            >
+                              {id}
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })()}
               </div>
             )}
           </div>


### PR DESCRIPTION
Target issue #38 
Earlier, in the config card listing page, tools and their corresponding vector store ids were not visible. It was creating issues for the user to ascertain which vector stores the config is taking in. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expandable Tools section displaying tool type, knowledge base count, and max results
  * Added expandable Vector Stores section showing all vector store IDs from configured tools in a compact list format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->