### PR TITLE
Update the typography and UI Improvements

### DIFF
--- a/app/(main)/speech-to-text/page.tsx
+++ b/app/(main)/speech-to-text/page.tsx
@@ -22,6 +22,7 @@ import { APIKey } from "@/app/lib/types/credentials";
 import WaveformVisualizer from "@/app/components/speech-to-text/WaveformVisualizer";
 import { computeWordDiff } from "@/app/components/speech-to-text/TranscriptionDiffViewer";
 import ErrorModal from "@/app/components/ErrorModal";
+import { getStatusColor } from "@/app/components/utils";
 
 type Tab = "datasets" | "evaluations";
 
@@ -3169,14 +3170,13 @@ function EvaluationsTab({
                     {filteredRuns.map((run) => {
                       const isCompleted =
                         run.status.toLowerCase() === "completed";
+                      const statusColor = getStatusColor(run.status);
                       return (
                         <div
                           key={run.id}
-                          className="rounded-lg overflow-hidden"
+                          className="rounded-lg overflow-hidden bg-bg-primary shadow-sm border-l-3"
                           style={{
-                            backgroundColor: colors.bg.primary,
-                            boxShadow: "0 1px 3px rgba(0, 0, 0, 0.06)",
-                            borderLeft: "3px solid #DCCFC3",
+                            borderLeftColor: statusColor.border,
                           }}
                         >
                           <div className="px-5 py-4">

--- a/app/components/DetailedResultsTable.tsx
+++ b/app/components/DetailedResultsTable.tsx
@@ -387,7 +387,7 @@ function GroupedResultsTable({ traces }: { traces: GroupedTraceItem[] }) {
       {/* Table Container - overflow-x-auto enables horizontal scroll when table exceeds viewport */}
       <div className="overflow-x-auto">
         <table
-          className="w-full border-collapse"
+          className="w-full border-collapse table-fixed"
           style={{ minWidth: `${tableMinWidth}px` }}
         >
           {/* Table Header - matching row format styling */}

--- a/app/components/prompt-editor/ConfigEditorPane.tsx
+++ b/app/components/prompt-editor/ConfigEditorPane.tsx
@@ -366,7 +366,6 @@ export default function ConfigEditorPane({
                 />
               </button>
 
-              {/* Dropdown Menu */}
               {isDropdownOpen && (
                 <div
                   className="absolute z-50 w-full mt-1 rounded-md shadow-lg max-h-64 overflow-auto"
@@ -642,7 +641,6 @@ export default function ConfigEditorPane({
               </p>
             </div>
 
-            {/* Model */}
             <div>
               <label
                 className="block text-xs font-semibold mb-2"

--- a/app/globals.css
+++ b/app/globals.css
@@ -15,8 +15,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-mono);
 }
 
 /* Background colors */
@@ -62,7 +62,7 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans), system-ui, sans-serif;
 }
 
 @keyframes fadeIn {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,18 +1,20 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Plus_Jakarta_Sans, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { ToastProvider } from "@/app/components/Toast";
 import { AuthProvider } from "@/app/lib/context/AuthContext";
 import { AppProvider } from "@/app/lib/context/AppContext";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const jakarta = Plus_Jakarta_Sans({
+  variable: "--font-sans",
   subsets: ["latin"],
+  display: "swap",
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-mono",
   subsets: ["latin"],
+  display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -28,7 +30,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${jakarta.variable} ${jetbrainsMono.variable} antialiased`}
       >
         <ToastProvider>
           <AuthProvider>

--- a/app/lib/models.ts
+++ b/app/lib/models.ts
@@ -17,9 +17,6 @@ export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
     { value: "gpt-4.1", label: "GPT-4.1" },
     { value: "gpt-4o", label: "GPT-4o" },
     { value: "gpt-4o-mini", label: "GPT-4o Mini" },
-    { value: "gpt-4-turbo", label: "GPT-4 Turbo" },
-    { value: "gpt-4", label: "GPT-4" },
-    { value: "gpt-3.5-turbo", label: "GPT-3.5 Turbo" },
   ],
   // anthropic: [
   //   { value: 'claude-3-5-sonnet-20241022', label: 'Claude 3.5 Sonnet' },


### PR DESCRIPTION
### Issue: https://github.com/ProjectTech4DevAI/kaapi-frontend/issues/107

### Summary:
- Update Typography for font stack for branding.
- Remove the `GPT-4`, `GPT-4-Turbo`, `GPT-3.5-turbo` models from the prompt-editor.
- Fixed the Evals tables UI in `Group by Question` tab.
- Add the border color in `STT` flow based on their evals status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated font styling with new typefaces (Plus Jakarta Sans and JetBrains Mono).
  * Enhanced visual distinction for evaluation run status with dynamic color coding.
  * Improved table layout formatting for results display.

* **Removed Features**
  * Removed OpenAI model options: gpt-4-turbo, gpt-4, and gpt-3.5-turbo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->