### PR TITLE
Evaluation: Category-wise analytics for Evals  

### DIFF
--- a/app/(main)/evaluations/[id]/page.tsx
+++ b/app/(main)/evaluations/[id]/page.tsx
@@ -27,8 +27,11 @@ import {
   exportRowCSV,
 } from "@/app/lib/utils/evaluationExport";
 import Sidebar from "@/app/components/Sidebar";
-import DetailedResultsTable from "@/app/components/evaluations/DetailedResultsTable";
-import MetricsOverview from "@/app/components/evaluations/MetricsOverview";
+import {
+  CategoryMetricsTable,
+  DetailedResultsTable,
+  MetricsOverview,
+} from "@/app/components/evaluations";
 import { Button, Modal, Loader, ConfigModal } from "@/app/components/ui";
 import { useToast } from "@/app/hooks/useToast";
 import { ResultsTableSkeleton } from "@/app/components";
@@ -245,6 +248,10 @@ export default function EvaluationReport() {
   const isNewFormat = hasSummaryScores(scoreObject);
   const summaryScores =
     isNewFormat && scoreObject ? scoreObject.summary_scores || [] : [];
+  const categoryMetrics =
+    scoreObject && isNewScoreObjectV2(scoreObject)
+      ? (scoreObject.category_metrics ?? [])
+      : [];
 
   const isJobInProgress =
     job.status.toLowerCase() !== "completed" &&
@@ -338,13 +345,18 @@ export default function EvaluationReport() {
           <div className="flex-1 overflow-auto p-6 bg-bg-secondary">
             <div className="max-w-7xl mx-auto space-y-6">
               {hasScore && isNewFormat ? (
-                <MetricsOverview
-                  job={job}
-                  summaryScores={summaryScores}
-                  isJobInProgress={isJobInProgress}
-                  isResyncing={isResyncing || isFormatSwitching}
-                  onResync={handleResync}
-                />
+                <>
+                  <MetricsOverview
+                    job={job}
+                    summaryScores={summaryScores}
+                    isJobInProgress={isJobInProgress}
+                    isResyncing={isResyncing || isFormatSwitching}
+                    onResync={handleResync}
+                  />
+                  {categoryMetrics.length > 0 && (
+                    <CategoryMetricsTable categoryMetrics={categoryMetrics} />
+                  )}
+                </>
               ) : (
                 <div className="rounded-lg p-6 text-center bg-bg-primary shadow-sm">
                   <p

--- a/app/(main)/evaluations/page.tsx
+++ b/app/(main)/evaluations/page.tsx
@@ -18,8 +18,7 @@ import { useApp } from "@/app/lib/context/AppContext";
 import { FeatureGateModal, LoginModal } from "@/app/components/auth";
 import { Loader, TabNavigation } from "@/app/components/ui";
 import { useToast } from "@/app/hooks/useToast";
-import DatasetsTab from "@/app/components/evaluations/DatasetsTab";
-import EvaluationsTab from "@/app/components/evaluations/EvaluationsTab";
+import { DatasetsTab, EvaluationsTab } from "@/app/components/evaluations";
 import { Tab } from "@/app/lib/types/evaluation";
 
 const leftPanelWidth = 450;
@@ -120,12 +119,13 @@ function SimplifiedEvalContent() {
           .toLowerCase(),
       );
       const required = ["question", "answer"];
+      const allowed = new Set([...required, "category"]);
       const hasRequired = required.every((col) => headers.includes(col));
-      const hasExtra = headers.some((col) => !required.includes(col));
+      const hasExtra = headers.some((col) => !allowed.has(col));
 
       if (!hasRequired || hasExtra) {
         toast.error(
-          'CSV must have exactly two columns: "question" and "answer"',
+          'CSV must have "question" and "answer" columns (optional: "category")',
         );
         event.target.value = "";
         return;

--- a/app/components/evaluations/CategoryMetricsTable.tsx
+++ b/app/components/evaluations/CategoryMetricsTable.tsx
@@ -26,10 +26,10 @@ export default function CategoryMetricsTable({
           Per-category breakdown across all evaluated items
         </p>
       </div>
-      <div className="overflow-x-auto">
+      <div className="max-h-80 overflow-y-auto overflow-x-auto">
         <table className="w-full border-collapse">
-          <thead>
-            <tr className="bg-bg-secondary border-b border-border">
+          <thead className="sticky top-0 z-10 bg-bg-secondary">
+            <tr className="border-b border-border">
               <th className="px-5 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wide text-text-secondary">
                 Category
               </th>

--- a/app/components/evaluations/CategoryMetricsTable.tsx
+++ b/app/components/evaluations/CategoryMetricsTable.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { CategoryMetric } from "@/app/lib/types/evaluation";
+
+interface CategoryMetricsTableProps {
+  categoryMetrics: CategoryMetric[];
+}
+
+function formatScore(value: number | null): string {
+  if (value === null || value === undefined) return "—";
+  return value.toFixed(3);
+}
+
+export default function CategoryMetricsTable({
+  categoryMetrics,
+}: CategoryMetricsTableProps) {
+  if (!categoryMetrics || categoryMetrics.length === 0) return null;
+
+  return (
+    <div className="rounded-lg bg-bg-primary shadow-sm">
+      <div className="px-5 py-3 border-b border-border">
+        <h3 className="text-sm font-semibold text-text-primary">
+          Metrics by Category
+        </h3>
+        <p className="text-xs text-text-secondary mt-0.5">
+          Per-category breakdown across all evaluated items
+        </p>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse">
+          <thead>
+            <tr className="bg-bg-secondary border-b border-border">
+              <th className="px-5 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wide text-text-secondary">
+                Category
+              </th>
+              <th className="px-5 py-2.5 text-right text-[11px] font-semibold uppercase tracking-wide text-text-secondary">
+                Total Evals
+              </th>
+              <th className="px-5 py-2.5 text-right text-[11px] font-semibold uppercase tracking-wide text-text-secondary">
+                Avg Cosine
+              </th>
+              <th className="px-5 py-2.5 text-right text-[11px] font-semibold uppercase tracking-wide text-text-secondary">
+                Avg Correctness
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {categoryMetrics.map((row) => (
+              <tr
+                key={row.category}
+                className="border-b border-border last:border-b-0 hover:bg-bg-secondary/40"
+              >
+                <td className="px-5 py-2.5 text-sm font-medium text-text-primary">
+                  {row.category}
+                </td>
+                <td className="px-5 py-2.5 text-sm text-right tabular-nums text-text-primary">
+                  {row.total_evals}
+                </td>
+                <td className="px-5 py-2.5 text-sm text-right tabular-nums text-text-primary">
+                  {formatScore(row.avg_cosine)}
+                </td>
+                <td className="px-5 py-2.5 text-sm text-right tabular-nums text-text-primary">
+                  {formatScore(row.avg_correctness)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/app/components/evaluations/CreateDatasetForm.tsx
+++ b/app/components/evaluations/CreateDatasetForm.tsx
@@ -214,6 +214,9 @@ export default function CreateDatasetForm({
               Format:{" "}
               <span className="font-mono text-text-primary">
                 question,answer
+              </span>{" "}
+              <span className="text-text-secondary">
+                (optional: <span className="font-mono">category</span>)
               </span>
             </p>
           </div>

--- a/app/components/evaluations/DetailedResultsTable.tsx
+++ b/app/components/evaluations/DetailedResultsTable.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/app/lib/utils/evaluation";
 import { formatScoreValue, getScoreByName } from "@/app/lib/utils";
 import { InfoTooltip } from "@/app/components/ui";
-import GroupedResultsTable from "@/app/components/evaluations/GroupedResultsTable";
+import { GroupedResultsTable } from "@/app/components/evaluations";
 
 interface DetailedResultsTableProps {
   job: EvalJob;
@@ -63,8 +63,13 @@ export default function DetailedResultsTable({
   const scoreNames =
     individual_scores[0]?.trace_scores?.map((s) => s.name) || [];
 
+  const hasAnyCategory = individual_scores.some(
+    (s) => (s.category ?? "").trim().length > 0,
+  );
+
   const COLUMN_WIDTHS = {
     index: 50,
+    category: 130,
     question: 250,
     groundTruth: 250,
     answer: 250,
@@ -72,6 +77,7 @@ export default function DetailedResultsTable({
   };
   const tableMinWidth =
     COLUMN_WIDTHS.index +
+    (hasAnyCategory ? COLUMN_WIDTHS.category : 0) +
     COLUMN_WIDTHS.question +
     COLUMN_WIDTHS.groundTruth +
     COLUMN_WIDTHS.answer +
@@ -90,6 +96,14 @@ export default function DetailedResultsTable({
                 className="px-4 py-3 text-left text-xs font-semibold uppercase text-bg-primary"
                 style={{ width: `${COLUMN_WIDTHS.index}px` }}
               ></th>
+              {hasAnyCategory && (
+                <th
+                  className="px-4 py-3 text-left text-xs font-semibold uppercase text-bg-primary"
+                  style={{ width: `${COLUMN_WIDTHS.category}px` }}
+                >
+                  Category
+                </th>
+              )}
               <th
                 className="px-4 py-3 text-left text-xs font-semibold uppercase text-bg-primary"
                 style={{ width: `${COLUMN_WIDTHS.question}px` }}
@@ -134,6 +148,18 @@ export default function DetailedResultsTable({
                   <td className="px-4 py-3 text-sm font-medium align-top text-text-secondary">
                     {index + 1}
                   </td>
+
+                  {hasAnyCategory && (
+                    <td className="px-4 py-3 align-top bg-bg-primary">
+                      {item.category ? (
+                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-accent-primary/10 text-accent-primary">
+                          {item.category}
+                        </span>
+                      ) : (
+                        <span className="text-xs text-text-secondary">—</span>
+                      )}
+                    </td>
+                  )}
 
                   <td className="px-4 py-3 align-top bg-bg-primary">
                     <div className="text-sm overflow-auto text-text-primary leading-normal max-h-[150px] wrap-break-word">

--- a/app/components/evaluations/EvalRunCard.tsx
+++ b/app/components/evaluations/EvalRunCard.tsx
@@ -7,9 +7,8 @@ import { getScoreObject } from "@/app/lib/utils/evaluation";
 import { getStatusColor } from "@/app/components/utils";
 import { timeAgo, formatCostUSD } from "@/app/lib/utils";
 import { Button, ConfigModal, InfoTooltip } from "@/app/components/ui";
-import ScoreDisplay from "@/app/components/evaluations/ScoreDisplay";
-import CostIcon from "@/app/components/icons/evaluations/CostIcon";
-import DatabaseIcon from "@/app/components/icons/evaluations/DatabaseIcon";
+import { ScoreDisplay } from "@/app/components/evaluations";
+import { CostIcon, DatabaseIcon } from "@/app/components/icons/evaluations";
 
 export interface EvalRunCardProps {
   job: EvalJob;

--- a/app/components/evaluations/GroupedResultsTable.tsx
+++ b/app/components/evaluations/GroupedResultsTable.tsx
@@ -22,10 +22,14 @@ export default function GroupedResultsTable({
   }
 
   const maxAnswers = Math.max(...traces.map((t) => t.llm_answers.length));
+  const hasAnyCategory = traces.some(
+    (t) => (t.category ?? "").trim().length > 0,
+  );
 
   // Fixed column widths (in pixels) for predictable layout
   const COLUMN_WIDTHS = {
     qId: 60,
+    category: 130,
     question: 200,
     groundTruth: 200,
     answer: 250,
@@ -34,7 +38,10 @@ export default function GroupedResultsTable({
   // Calculate minimum table width based on number of answers
   // This ensures horizontal scroll activates at the right point
   const fixedColumnsWidth =
-    COLUMN_WIDTHS.qId + COLUMN_WIDTHS.question + COLUMN_WIDTHS.groundTruth;
+    COLUMN_WIDTHS.qId +
+    (hasAnyCategory ? COLUMN_WIDTHS.category : 0) +
+    COLUMN_WIDTHS.question +
+    COLUMN_WIDTHS.groundTruth;
   const tableMinWidth = fixedColumnsWidth + maxAnswers * COLUMN_WIDTHS.answer;
 
   return (
@@ -55,6 +62,17 @@ export default function GroupedResultsTable({
               >
                 Q.ID
               </th>
+              {hasAnyCategory && (
+                <th
+                  className="px-4 py-3 text-left text-xs font-semibold uppercase text-bg-primary"
+                  style={{
+                    width: `${COLUMN_WIDTHS.category}px`,
+                    minWidth: `${COLUMN_WIDTHS.category}px`,
+                  }}
+                >
+                  Category
+                </th>
+              )}
               <th
                 className="px-4 py-3 text-left text-xs font-semibold uppercase text-bg-primary"
                 style={{
@@ -99,6 +117,18 @@ export default function GroupedResultsTable({
                     {group.question_id}
                   </td>
 
+                  {hasAnyCategory && (
+                    <td className="px-4 pt-3 pb-1 align-top bg-accent-subtle/50">
+                      {group.category ? (
+                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-accent-primary/10 text-accent-primary">
+                          {group.category}
+                        </span>
+                      ) : (
+                        <span className="text-xs text-text-secondary">—</span>
+                      )}
+                    </td>
+                  )}
+
                   <td className="px-4 pt-3 pb-1 align-top bg-accent-subtle/50">
                     <div className="text-sm overflow-auto text-text-primary leading-normal max-h-[150px] wrap-break-word">
                       {group.question}
@@ -134,6 +164,9 @@ export default function GroupedResultsTable({
                   className="border-b border-border"
                 >
                   <td className="px-4 pt-1 pb-3" />
+                  {hasAnyCategory && (
+                    <td className="px-4 pt-1 pb-3 bg-accent-subtle/50" />
+                  )}
                   <td className="px-4 pt-1 pb-3 bg-accent-subtle/50" />
                   <td className="px-4 pt-1 pb-3 bg-accent-subtle/50" />
 

--- a/app/components/evaluations/index.ts
+++ b/app/components/evaluations/index.ts
@@ -1,0 +1,15 @@
+export { default as CategoryMetricsTable } from "./CategoryMetricsTable";
+export { default as CreateDatasetForm } from "./CreateDatasetForm";
+export { default as DatasetCard } from "./DatasetCard";
+export { default as DatasetsTab } from "./DatasetsTab";
+export { default as DeleteDatasetModal } from "./DeleteDatasetModal";
+export { default as DetailedResultsTable } from "./DetailedResultsTable";
+export { default as EvalDatasetDescription } from "./EvalDatasetDescription";
+export { default as EvalRunCard } from "./EvalRunCard";
+export { default as EvalRunsList } from "./EvalRunsList";
+export { default as EvaluationsTab } from "./EvaluationsTab";
+export { default as GroupedResultsTable } from "./GroupedResultsTable";
+export { default as MetricsOverview } from "./MetricsOverview";
+export { default as RunEvaluationForm } from "./RunEvaluationForm";
+export { default as ScoreDisplay } from "./ScoreDisplay";
+export { default as ViewDatasetModal } from "./ViewDatasetModal";

--- a/app/components/icons/evaluations/index.ts
+++ b/app/components/icons/evaluations/index.ts
@@ -1,0 +1,7 @@
+export { default as ChevronLeftIcon } from "./ChevronLeftIcon";
+export { default as ChevronUpIcon } from "./ChevronUpIcon";
+export { default as CostIcon } from "./CostIcon";
+export { default as DatabaseIcon } from "./DatabaseIcon";
+export { default as EditIcon } from "./EditIcon";
+export { default as GroupIcon } from "./GroupIcon";
+export { default as MenuIcon } from "./MenuIcon";

--- a/app/hooks/index.ts
+++ b/app/hooks/index.ts
@@ -1,4 +1,4 @@
 export { useConfigs } from "./useConfigs";
 export { useInfiniteScroll } from "./useInfiniteScroll";
 export { usePaginatedList } from "./usePaginatedList";
-export type { UsePaginatedListResult } from "./usePaginatedList";
+export type { UsePaginatedListResult } from "@/app/lib/types/pagination";

--- a/app/hooks/usePaginatedList.ts
+++ b/app/hooks/usePaginatedList.ts
@@ -19,23 +19,10 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { apiFetch } from "@/app/lib/apiClient";
 import { useAuth } from "@/app/lib/context/AuthContext";
 import { DEFAULT_PAGE_LIMIT } from "@/app/lib/constants";
-
-interface PaginatedResponse<T> {
-  success: boolean;
-  data: T[] | null;
-  error?: string | null;
-  metadata?: { has_more?: boolean } | null;
-}
-
-export interface UsePaginatedListResult<T> {
-  items: T[];
-  isLoading: boolean;
-  isLoadingMore: boolean;
-  hasMore: boolean;
-  error: string | null;
-  loadMore: () => void;
-  refetch: () => void;
-}
+import {
+  PaginatedResponse,
+  UsePaginatedListResult,
+} from "@/app/lib/types/pagination";
 
 export function usePaginatedList<T>(options: {
   endpoint: string;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body
         className={`${inter.variable} ${jetbrainsMono.variable} antialiased`}
       >

--- a/app/lib/types/evaluation.ts
+++ b/app/lib/types/evaluation.ts
@@ -44,10 +44,6 @@ export interface IndividualScore {
   trace_scores: TraceScore[];
 }
 
-/**
- * Aggregate metrics for one category, computed server-side from the eval
- * traces. `avg_correctness` is null when the eval didn't run an LLM judge.
- */
 export interface CategoryMetric {
   category: string;
   total_evals: number;

--- a/app/lib/types/evaluation.ts
+++ b/app/lib/types/evaluation.ts
@@ -12,6 +12,8 @@ export interface TraceItem {
   question: string;
   llm_answer: string;
   ground_truth_answer: string;
+  question_id?: number;
+  category?: string;
   scores: TraceScore[];
 }
 
@@ -21,11 +23,13 @@ export interface GroupedTraceItem {
   ground_truth_answer: string;
   llm_answers: string[];
   trace_ids: string[];
+  category?: string;
   scores: TraceScore[][];
 }
 
 export interface IndividualScore {
   trace_id: string;
+  category?: string;
   input?: {
     question: string;
   };
@@ -40,6 +44,17 @@ export interface IndividualScore {
   trace_scores: TraceScore[];
 }
 
+/**
+ * Aggregate metrics for one category, computed server-side from the eval
+ * traces. `avg_correctness` is null when the eval didn't run an LLM judge.
+ */
+export interface CategoryMetric {
+  category: string;
+  total_evals: number;
+  avg_cosine: number | null;
+  avg_correctness: number | null;
+}
+
 export interface SummaryScore {
   name: string;
   avg?: number;
@@ -52,6 +67,7 @@ export interface SummaryScore {
 export interface NewScoreObjectV2 {
   summary_scores: SummaryScore[];
   traces: TraceItem[] | GroupedTraceItem[];
+  category_metrics?: CategoryMetric[];
 }
 
 export interface PerItemScore {

--- a/app/lib/types/pagination.ts
+++ b/app/lib/types/pagination.ts
@@ -1,0 +1,16 @@
+export interface PaginatedResponse<T> {
+  success: boolean;
+  data: T[] | null;
+  error?: string | null;
+  metadata?: { has_more?: boolean } | null;
+}
+
+export interface UsePaginatedListResult<T> {
+  items: T[];
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  hasMore: boolean;
+  error: string | null;
+  loadMore: () => void;
+  refetch: () => void;
+}

--- a/app/lib/utils/evaluation.ts
+++ b/app/lib/utils/evaluation.ts
@@ -42,6 +42,7 @@ export function normalizeToIndividualScores(
     if ("llm_answer" in trace) {
       return {
         trace_id: trace.trace_id,
+        category: trace.category,
         input: { question: trace.question },
         output: { answer: trace.llm_answer },
         metadata: { ground_truth: trace.ground_truth_answer },

--- a/app/lib/utils/evaluationExport.ts
+++ b/app/lib/utils/evaluationExport.ts
@@ -27,7 +27,12 @@ export const exportGroupedCSV = (
 ): number => {
   const maxAnswers = Math.max(...traces.map((g) => g.llm_answers.length));
   const scoreNames = traces[0]?.scores[0]?.map((s) => s.name) || [];
-  let csvContent = "Question ID,Question,Ground Truth";
+  const hasAnyCategory = traces.some(
+    (t) => (t.category ?? "").trim().length > 0,
+  );
+  let csvContent = "Question ID";
+  if (hasAnyCategory) csvContent += ",Category";
+  csvContent += ",Question,Ground Truth";
   for (let i = 1; i <= maxAnswers; i++) {
     csvContent += `,LLM Answer ${i},Trace ID ${i}`;
     scoreNames.forEach((name) => {
@@ -36,11 +41,12 @@ export const exportGroupedCSV = (
   }
   csvContent += "\n";
   traces.forEach((group) => {
-    const row: string[] = [
-      String(group.question_id),
+    const row: string[] = [String(group.question_id)];
+    if (hasAnyCategory) row.push(sanitizeCSVCell(group.category || ""));
+    row.push(
       sanitizeCSVCell(group.question || ""),
       sanitizeCSVCell(group.ground_truth_answer || ""),
-    ];
+    );
     for (let i = 0; i < maxAnswers; i++) {
       row.push(
         `"${(group.llm_answers[i] || "").replace(/"/g, '""').replace(/\n/g, " ")}"`,
@@ -75,8 +81,12 @@ export const exportRowCSV = (
   let csvContent = "";
   const firstItem = individual_scores[0];
   const scoreNames = firstItem?.trace_scores?.map((s) => s.name) || [];
+  const hasAnyCategory = individual_scores.some(
+    (s) => (s.category ?? "").trim().length > 0,
+  );
   csvContent +=
     "Counter,Trace ID,Job ID,Run Name,Dataset,Model,Status,Total Items,";
+  if (hasAnyCategory) csvContent += "Category,";
   csvContent += "Question,Answer,Ground Truth,";
   csvContent +=
     scoreNames.map((name) => `${name},${name} (comment)`).join(",") + "\n";
@@ -92,6 +102,7 @@ export const exportRowCSV = (
       assistantConfig?.model || job.config?.model || "N/A",
       job.status,
       job.total_items,
+      ...(hasAnyCategory ? [sanitizeCSVCell(item.category || "")] : []),
       `"${(item.input?.question || "").replace(/"/g, '""').replace(/\n/g, " ")}"`,
       `"${(item.output?.answer || "").replace(/"/g, '""').replace(/\n/g, " ")}"`,
       `"${(item.metadata?.ground_truth || "").replace(/"/g, '""').replace(/\n/g, " ")}"`,


### PR DESCRIPTION
### Issue: https://github.com/ProjectTech4DevAI/kaapi-backend/issues/844

### Summary:
In this PR,
  - Added a new Category Metrics table on the evaluation detail page showing total evals, avg cosine, and avg correctness per category.
  - Added an optional category column to the results tables (detailed + grouped), shown only when category data exists.
  - CSV upload now accepts the optional category column, with updated validation and form instructions.
  - CSV export includes the category column when present.
  - Minor cleanup: barrel exports for evaluation `components/icons`, moved pagination types to their own file, and a hydration warning fix.