### PR TITLE
Evaluation: Fast Evals UI Updates

### DIFF
--- a/app/(main)/evaluations/[id]/page.tsx
+++ b/app/(main)/evaluations/[id]/page.tsx
@@ -33,7 +33,13 @@ import {
   MetricsOverview,
   RunModeBadge,
 } from "@/app/components/evaluations";
-import { Button, Modal, Loader, ConfigModal } from "@/app/components/ui";
+import {
+  Button,
+  ConfigModal,
+  Loader,
+  Modal,
+  RadioGroup,
+} from "@/app/components/ui";
 import { useToast } from "@/app/hooks/useToast";
 import { ResultsTableSkeleton } from "@/app/components";
 import {
@@ -259,9 +265,6 @@ export default function EvaluationReport() {
     job.status.toLowerCase() !== "completed" &&
     job.status.toLowerCase() !== "failed";
 
-  const segmentedClass =
-    "inline-flex items-center gap-1.5 px-4 py-1.5 text-xs font-semibold rounded-full transition-colors cursor-pointer text-accent-primary/70 hover:text-accent-primary data-[selected=true]:bg-accent-primary data-[selected=true]:text-white data-[selected=true]:shadow-[0_1px_2px_rgba(0,0,0,0.12)] data-[selected=true]:hover:bg-accent-hover";
-
   return (
     <div className="w-full h-screen flex flex-col bg-bg-secondary">
       <div className="flex flex-1 overflow-hidden">
@@ -301,30 +304,38 @@ export default function EvaluationReport() {
             </div>
 
             <div className="flex flex-wrap items-center gap-2 sm:gap-3 shrink-0 relative z-10">
-              <div className="inline-flex rounded-full p-1 bg-accent-primary/10">
-                <button
-                  type="button"
-                  onClick={() => setExportFormat("row")}
-                  disabled={isFormatSwitching || isResyncing}
-                  data-selected={exportFormat === "row"}
-                  className={`${segmentedClass} disabled:cursor-not-allowed disabled:opacity-60`}
-                >
-                  <MenuIcon className="w-3.5 h-3.5 pointer-events-none" />
-                  <span className="hidden sm:inline">Individual Rows</span>
-                  <span className="sm:hidden">Rows</span>
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setExportFormat("grouped")}
-                  disabled={isFormatSwitching || isResyncing}
-                  data-selected={exportFormat === "grouped"}
-                  className={`${segmentedClass} disabled:cursor-not-allowed disabled:opacity-60`}
-                >
-                  <GroupIcon className="pointer-events-none" />
-                  <span className="hidden sm:inline">Group by Questions</span>
-                  <span className="sm:hidden">Grouped</span>
-                </button>
-              </div>
+              <RadioGroup<"row" | "grouped">
+                ariaLabel="Export format"
+                value={exportFormat}
+                onChange={setExportFormat}
+                disabled={isFormatSwitching || isResyncing}
+                options={[
+                  {
+                    value: "row",
+                    label: (
+                      <>
+                        <MenuIcon className="w-3.5 h-3.5 pointer-events-none" />
+                        <span className="hidden sm:inline">
+                          Individual Rows
+                        </span>
+                        <span className="sm:hidden">Rows</span>
+                      </>
+                    ),
+                  },
+                  {
+                    value: "grouped",
+                    label: (
+                      <>
+                        <GroupIcon className="pointer-events-none" />
+                        <span className="hidden sm:inline">
+                          Group by Questions
+                        </span>
+                        <span className="sm:hidden">Grouped</span>
+                      </>
+                    ),
+                  },
+                ]}
+              />
               <Button
                 variant="outline"
                 size="sm"

--- a/app/(main)/evaluations/[id]/page.tsx
+++ b/app/(main)/evaluations/[id]/page.tsx
@@ -31,6 +31,7 @@ import {
   CategoryMetricsTable,
   DetailedResultsTable,
   MetricsOverview,
+  RunModeBadge,
 } from "@/app/components/evaluations";
 import { Button, Modal, Loader, ConfigModal } from "@/app/components/ui";
 import { useToast } from "@/app/hooks/useToast";
@@ -289,6 +290,7 @@ export default function EvaluationReport() {
                 <h1 className="text-base font-semibold truncate min-w-0 text-text-primary tracking-[-0.01em]">
                   {job.run_name}
                 </h1>
+                <RunModeBadge runMode={job.run_mode} />
                 <span className="flex items-center gap-1 text-xs shrink-0 text-text-secondary">
                   <DatabaseIcon className="shrink-0" />
                   <span className="truncate max-w-[200px]">

--- a/app/(main)/evaluations/page.tsx
+++ b/app/(main)/evaluations/page.tsx
@@ -19,7 +19,7 @@ import { FeatureGateModal, LoginModal } from "@/app/components/auth";
 import { Loader, TabNavigation } from "@/app/components/ui";
 import { useToast } from "@/app/hooks/useToast";
 import { DatasetsTab, EvaluationsTab } from "@/app/components/evaluations";
-import { Tab } from "@/app/lib/types/evaluation";
+import { RunMode, Tab } from "@/app/lib/types/evaluation";
 
 const leftPanelWidth = 450;
 
@@ -62,6 +62,9 @@ function SimplifiedEvalContent() {
     },
   );
   const [isEvaluating, setIsEvaluating] = useState(false);
+  const [runMode, setRunMode] = useState<RunMode>("batch");
+  const [nameError, setNameError] = useState<string>("");
+  const [submitError, setSubmitError] = useState<string>("");
 
   useEffect(() => {
     setMounted(true);
@@ -198,6 +201,9 @@ function SimplifiedEvalContent() {
   };
 
   const handleRunEvaluation = async () => {
+    setNameError("");
+    setSubmitError("");
+
     if (!isAuthenticated) {
       toast.error("Please log in to run evaluations.");
       return;
@@ -217,12 +223,15 @@ function SimplifiedEvalContent() {
 
     setIsEvaluating(true);
     try {
-      const payload = {
+      // `run_mode` is only sent when "fast" — omitting it means the backend
+      // defaults to batch, which is the safe behaviour for older clients too.
+      const payload: Record<string, unknown> = {
         dataset_id: parseInt(selectedDatasetId),
         experiment_name: experimentName.trim(),
         config_id: selectedConfigId,
         config_version: selectedConfigVersion,
       };
+      if (runMode === "fast") payload.run_mode = "fast";
 
       await apiFetch("/api/evaluations", apiKey, {
         method: "POST",
@@ -234,12 +243,33 @@ function SimplifiedEvalContent() {
       setSelectedDatasetId("");
       setSelectedConfigId("");
       setSelectedConfigVersion(0);
+      setRunMode("batch");
       toast.success(`Evaluation created!`);
       return true;
     } catch (error: unknown) {
-      toast.error(
-        `Failed to run evaluation: ${error instanceof Error ? error.message : "Unknown error"}`,
-      );
+      const msg = (
+        error instanceof Error ? error.message : String(error)
+      ).toLowerCase();
+      if (
+        msg.includes("run_name_already_exists") ||
+        msg.includes("already exists")
+      ) {
+        setNameError("A run with this name already exists");
+      } else if (msg.includes("config_type_unsupported")) {
+        setSubmitError(
+          "Fast mode only supports text-evaluation configs. Pick a text config or switch to Batch.",
+        );
+      } else if (msg.includes("dataset_too_large_for_fast")) {
+        setSubmitError(
+          "This dataset is too large for Fast mode (limit is ~10 unique rows / 50 items). Pick a smaller dataset or switch to Batch.",
+        );
+      } else {
+        setSubmitError(
+          error instanceof Error
+            ? error.message
+            : "Failed to create evaluation",
+        );
+      }
       setIsEvaluating(false);
       return false;
     }
@@ -317,10 +347,17 @@ function SimplifiedEvalContent() {
                 setSelectedConfigVersion(configVersion);
               }}
               experimentName={experimentName}
-              setExperimentName={setExperimentName}
+              setExperimentName={(name) => {
+                setNameError("");
+                setExperimentName(name);
+              }}
               isEvaluating={isEvaluating}
               handleRunEvaluation={handleRunEvaluation}
               setActiveTab={setActiveTab}
+              runMode={runMode}
+              setRunMode={setRunMode}
+              nameError={nameError}
+              submitError={submitError}
             />
           )}
         </div>

--- a/app/(main)/evaluations/page.tsx
+++ b/app/(main)/evaluations/page.tsx
@@ -247,28 +247,23 @@ function SimplifiedEvalContent() {
       toast.success(`Evaluation created!`);
       return true;
     } catch (error: unknown) {
-      const msg = (
-        error instanceof Error ? error.message : String(error)
-      ).toLowerCase();
-      if (
-        msg.includes("run_name_already_exists") ||
-        msg.includes("already exists")
-      ) {
-        setNameError("A run with this name already exists");
-      } else if (msg.includes("config_type_unsupported")) {
-        setSubmitError(
-          "Fast mode only supports text-evaluation configs. Pick a text config or switch to Batch.",
-        );
-      } else if (msg.includes("dataset_too_large_for_fast")) {
-        setSubmitError(
-          "This dataset is too large for Fast mode (limit is ~10 unique rows / 50 items). Pick a smaller dataset or switch to Batch.",
-        );
-      } else {
-        setSubmitError(
-          error instanceof Error
-            ? error.message
-            : "Failed to create evaluation",
-        );
+      const code = error instanceof Error ? error.message : String(error);
+      switch (code) {
+        case "run_name_already_exists":
+          setNameError("A run with this name already exists");
+          break;
+        case "config_type_unsupported":
+          setSubmitError(
+            "Fast mode only supports text-evaluation configs. Pick a text config or switch to Batch.",
+          );
+          break;
+        case "dataset_too_large_for_fast":
+          setSubmitError(
+            "This dataset is too large for Fast mode (limit is ~10 unique rows / 50 items). Pick a smaller dataset or switch to Batch.",
+          );
+          break;
+        default:
+          setSubmitError(code || "Failed to create evaluation");
       }
       setIsEvaluating(false);
       return false;

--- a/app/components/evaluations/EvalRunCard.tsx
+++ b/app/components/evaluations/EvalRunCard.tsx
@@ -7,7 +7,7 @@ import { getScoreObject } from "@/app/lib/utils/evaluation";
 import { getStatusColor } from "@/app/components/utils";
 import { timeAgo, formatCostUSD } from "@/app/lib/utils";
 import { Button, ConfigModal, InfoTooltip } from "@/app/components/ui";
-import { ScoreDisplay } from "@/app/components/evaluations";
+import { RunModeBadge, ScoreDisplay } from "@/app/components/evaluations";
 import { CostIcon, DatabaseIcon } from "@/app/components/icons/evaluations";
 
 export interface EvalRunCardProps {
@@ -33,8 +33,11 @@ export default function EvalRunCard({
       <div className="px-5 py-4">
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0 flex-1">
-            <div className="text-sm font-semibold truncate text-text-primary">
-              {job.run_name}
+            <div className="flex items-center gap-2 min-w-0">
+              <span className="text-sm font-semibold truncate text-text-primary">
+                {job.run_name}
+              </span>
+              <RunModeBadge runMode={job.run_mode} />
             </div>
             {job.inserted_at && (
               <div className="text-xs mt-0.5 text-text-secondary">

--- a/app/components/evaluations/EvaluationsTab.tsx
+++ b/app/components/evaluations/EvaluationsTab.tsx
@@ -3,7 +3,12 @@
 import { useState, useEffect, useCallback } from "react";
 import { apiFetch } from "@/app/lib/apiClient";
 import { Dataset } from "@/app/lib/types/dataset";
-import { EvalJob, AssistantConfig, Tab } from "@/app/lib/types/evaluation";
+import {
+  AssistantConfig,
+  EvalJob,
+  RunMode,
+  Tab,
+} from "@/app/lib/types/evaluation";
 import { useAuth } from "@/app/lib/context/AuthContext";
 import { Modal } from "@/app/components/ui";
 import EvalRunsList from "./EvalRunsList";
@@ -23,6 +28,10 @@ export interface EvaluationsTabProps {
   isEvaluating: boolean;
   handleRunEvaluation: () => Promise<boolean>;
   setActiveTab: (tab: Tab) => void;
+  runMode: RunMode;
+  setRunMode: (mode: RunMode) => void;
+  nameError?: string;
+  submitError?: string;
 }
 
 export default function EvaluationsTab({
@@ -39,6 +48,10 @@ export default function EvaluationsTab({
   isEvaluating,
   handleRunEvaluation,
   setActiveTab,
+  runMode,
+  setRunMode,
+  nameError,
+  submitError,
 }: EvaluationsTabProps) {
   const [evalJobs, setEvalJobs] = useState<EvalJob[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -52,12 +65,15 @@ export default function EvaluationsTab({
   const selectedDataset = storedDatasets.find(
     (d) => d.dataset_id.toString() === selectedDatasetId,
   );
+  const fastModeMismatch =
+    runMode === "fast" && selectedDataset?.eligible_for_fast === false;
   const canRun = Boolean(
     experimentName.trim() &&
     selectedDatasetId &&
     selectedConfigId &&
     selectedConfigVersion &&
-    !isEvaluating,
+    !isEvaluating &&
+    !fastModeMismatch,
   );
 
   const { isAuthenticated } = useAuth();
@@ -142,11 +158,14 @@ export default function EvaluationsTab({
     canRun,
     onRun: handleRun,
     setActiveTab,
+    runMode,
+    setRunMode,
+    nameError,
+    submitError,
   };
 
   return (
     <div className="flex-1 flex overflow-hidden">
-      {/* Left Panel - Evaluation Runs */}
       <EvalRunsList
         evalJobs={evalJobs}
         assistantConfigs={assistantConfigs}
@@ -158,7 +177,6 @@ export default function EvaluationsTab({
         onCreateNew={() => setIsFormModalOpen(true)}
       />
 
-      {/* Right Panel - Configuration (lg+ only) */}
       <div
         className="hidden lg:flex shrink-0 border-l flex-col overflow-hidden bg-bg-primary border-border"
         style={{ width: `${leftPanelWidth}px` }}

--- a/app/components/evaluations/RunEvaluationForm.tsx
+++ b/app/components/evaluations/RunEvaluationForm.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { Dataset } from "@/app/lib/types/dataset";
-import { Button, Field, Select } from "@/app/components/ui";
+import { Button, Field, InfoTooltip, Select } from "@/app/components/ui";
 import { CheckCircleIcon, PlayIcon } from "@/app/components/icons";
 import ConfigSelector from "@/app/components/ConfigSelector";
 import EvalDatasetDescription from "./EvalDatasetDescription";
-import { Tab } from "@/app/lib/types/evaluation";
+import { RunMode, Tab } from "@/app/lib/types/evaluation";
 
 interface RunEvaluationFormProps {
   storedDatasets: Dataset[];
@@ -21,6 +21,10 @@ interface RunEvaluationFormProps {
   canRun: boolean;
   onRun: () => void;
   setActiveTab: (tab: Tab) => void;
+  runMode: RunMode;
+  setRunMode: (mode: RunMode) => void;
+  nameError?: string;
+  submitError?: string;
 }
 
 export default function RunEvaluationForm({
@@ -37,7 +41,13 @@ export default function RunEvaluationForm({
   canRun,
   onRun,
   setActiveTab,
+  runMode,
+  setRunMode,
+  nameError,
+  submitError,
 }: RunEvaluationFormProps) {
+  const fastEligible = selectedDataset?.eligible_for_fast !== false;
+
   return (
     <div className="flex-1 overflow-auto p-4 space-y-4">
       <div>
@@ -49,13 +59,16 @@ export default function RunEvaluationForm({
         </p>
       </div>
 
-      <Field
-        label="Name *"
-        value={experimentName}
-        onChange={setExperimentName}
-        placeholder="e.g., test_run_1"
-        disabled={isEvaluating}
-      />
+      <div>
+        <Field
+          label="Name *"
+          value={experimentName}
+          onChange={setExperimentName}
+          placeholder="e.g., test_run_1"
+          disabled={isEvaluating}
+          error={nameError}
+        />
+      </div>
 
       <ConfigSelector
         selectedConfigId={selectedConfigId}
@@ -116,6 +129,70 @@ export default function RunEvaluationForm({
               </div>
             </div>
           </div>
+        </div>
+      )}
+
+      <div>
+        <label className="inline-flex items-center text-xs font-medium mb-1.5 text-text-secondary">
+          Run Mode
+          <InfoTooltip
+            text={
+              <>
+                <strong>Batch</strong> — the standard mode. Runs every item in
+                the dataset and produces full metrics.
+                <br />
+                <br />
+                <strong>Fast</strong> — short-loop mode for quick iteration.
+                Only works on small datasets (≤10 unique rows / ≤50 items) and
+                text-evaluation configs.
+              </>
+            }
+          />
+        </label>
+        <div
+          role="radiogroup"
+          aria-label="Run mode"
+          className="inline-flex rounded-full p-1 bg-accent-primary/10 ml-4"
+        >
+          <button
+            type="button"
+            role="radio"
+            aria-checked={runMode === "batch"}
+            data-selected={runMode === "batch"}
+            onClick={() => setRunMode("batch")}
+            disabled={isEvaluating}
+            className="inline-flex items-center gap-1.5 px-4 py-1.5 text-xs font-semibold rounded-full transition-colors cursor-pointer text-accent-primary/70 hover:text-accent-primary data-[selected=true]:bg-accent-primary data-[selected=true]:text-white data-[selected=true]:shadow-[0_1px_2px_rgba(0,0,0,0.12)] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Batch
+          </button>
+          <button
+            type="button"
+            role="radio"
+            aria-checked={runMode === "fast"}
+            data-selected={runMode === "fast"}
+            onClick={() => setRunMode("fast")}
+            disabled={isEvaluating}
+            title={
+              selectedDataset && !fastEligible
+                ? "This dataset is too large for Fast mode — pick a smaller one"
+                : undefined
+            }
+            className="inline-flex items-center gap-1.5 px-4 py-1.5 text-xs font-semibold rounded-full transition-colors cursor-pointer text-accent-primary/70 hover:text-accent-primary data-[selected=true]:bg-accent-primary data-[selected=true]:text-white data-[selected=true]:shadow-[0_1px_2px_rgba(0,0,0,0.12)] disabled:cursor-not-allowed disabled:text-text-secondary/40 disabled:hover:text-text-secondary/40"
+          >
+            Fast
+          </button>
+        </div>
+        {selectedDataset && !fastEligible && (
+          <p className="text-xs mt-1.5 text-status-error-text">
+            Fast mode isn&apos;t available for this dataset — pick a smaller one
+            or stay on Batch.
+          </p>
+        )}
+      </div>
+
+      {submitError && (
+        <div className="rounded-lg px-3 py-2 bg-status-error-bg border border-status-error-border">
+          <p className="text-sm text-status-error-text">{submitError}</p>
         </div>
       )}
 

--- a/app/components/evaluations/RunEvaluationForm.tsx
+++ b/app/components/evaluations/RunEvaluationForm.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { Dataset } from "@/app/lib/types/dataset";
-import { Button, Field, InfoTooltip, Select } from "@/app/components/ui";
+import {
+  Button,
+  Field,
+  InfoTooltip,
+  RadioGroup,
+  Select,
+} from "@/app/components/ui";
 import { CheckCircleIcon, PlayIcon } from "@/app/components/icons";
 import ConfigSelector from "@/app/components/ConfigSelector";
 import EvalDatasetDescription from "./EvalDatasetDescription";
@@ -149,39 +155,24 @@ export default function RunEvaluationForm({
             }
           />
         </label>
-        <div
-          role="radiogroup"
-          aria-label="Run mode"
-          className="inline-flex rounded-full p-1 bg-accent-primary/10 ml-4"
-        >
-          <button
-            type="button"
-            role="radio"
-            aria-checked={runMode === "batch"}
-            data-selected={runMode === "batch"}
-            onClick={() => setRunMode("batch")}
-            disabled={isEvaluating}
-            className="inline-flex items-center gap-1.5 px-4 py-1.5 text-xs font-semibold rounded-full transition-colors cursor-pointer text-accent-primary/70 hover:text-accent-primary data-[selected=true]:bg-accent-primary data-[selected=true]:text-white data-[selected=true]:shadow-[0_1px_2px_rgba(0,0,0,0.12)] disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            Batch
-          </button>
-          <button
-            type="button"
-            role="radio"
-            aria-checked={runMode === "fast"}
-            data-selected={runMode === "fast"}
-            onClick={() => setRunMode("fast")}
-            disabled={isEvaluating}
-            title={
-              selectedDataset && !fastEligible
-                ? "This dataset is too large for Fast mode — pick a smaller one"
-                : undefined
-            }
-            className="inline-flex items-center gap-1.5 px-4 py-1.5 text-xs font-semibold rounded-full transition-colors cursor-pointer text-accent-primary/70 hover:text-accent-primary data-[selected=true]:bg-accent-primary data-[selected=true]:text-white data-[selected=true]:shadow-[0_1px_2px_rgba(0,0,0,0.12)] disabled:cursor-not-allowed disabled:text-text-secondary/40 disabled:hover:text-text-secondary/40"
-          >
-            Fast
-          </button>
-        </div>
+        <RadioGroup<RunMode>
+          ariaLabel="Run mode"
+          className="ml-4"
+          value={runMode}
+          onChange={setRunMode}
+          disabled={isEvaluating}
+          options={[
+            { value: "batch", label: "Batch" },
+            {
+              value: "fast",
+              label: "Fast",
+              title:
+                selectedDataset && !fastEligible
+                  ? "This dataset is too large for Fast mode — pick a smaller one"
+                  : undefined,
+            },
+          ]}
+        />
         {selectedDataset && !fastEligible && (
           <p className="text-xs mt-1.5 text-status-error-text">
             Fast mode isn&apos;t available for this dataset — pick a smaller one

--- a/app/components/evaluations/RunModeBadge.tsx
+++ b/app/components/evaluations/RunModeBadge.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { RunMode } from "@/app/lib/types/evaluation";
+
+interface RunModeBadgeProps {
+  runMode?: RunMode;
+  size?: "sm" | "md";
+}
+
+export default function RunModeBadge({
+  runMode,
+  size = "sm",
+}: RunModeBadgeProps) {
+  if (!runMode) return null;
+  const isFast = runMode === "fast";
+  const padding =
+    size === "md" ? "px-2.5 py-1 text-xs" : "px-2 py-0.5 text-[10px]";
+  const colour = isFast
+    ? "bg-accent-secondary text-text-primary"
+    : "bg-accent-primary/10 text-accent-primary";
+  return (
+    <span
+      className={`inline-flex items-center shrink-0 rounded-full font-semibold uppercase tracking-wide ${padding} ${colour}`}
+      title={isFast ? "Fast mode" : "Batch mode"}
+    >
+      {isFast ? "Fast" : "Batch"}
+    </span>
+  );
+}

--- a/app/components/evaluations/index.ts
+++ b/app/components/evaluations/index.ts
@@ -11,5 +11,6 @@ export { default as EvaluationsTab } from "./EvaluationsTab";
 export { default as GroupedResultsTable } from "./GroupedResultsTable";
 export { default as MetricsOverview } from "./MetricsOverview";
 export { default as RunEvaluationForm } from "./RunEvaluationForm";
+export { default as RunModeBadge } from "./RunModeBadge";
 export { default as ScoreDisplay } from "./ScoreDisplay";
 export { default as ViewDatasetModal } from "./ViewDatasetModal";

--- a/app/components/ui/RadioGroup.tsx
+++ b/app/components/ui/RadioGroup.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { ReactNode } from "react";
+
+export interface RadioGroupOption<T extends string = string> {
+  value: T;
+  label: ReactNode;
+  disabled?: boolean;
+  title?: string;
+}
+
+export interface RadioGroupProps<T extends string = string> {
+  options: RadioGroupOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  disabled?: boolean;
+  ariaLabel?: string;
+  className?: string;
+}
+
+/**
+ * Generic over the value type so consumers get type-safe `onChange` callbacks:
+ *
+ * ```tsx
+ * <RadioGroup<"batch" | "fast">
+ *   value={runMode}
+ *   onChange={setRunMode}
+ *   options={[
+ *     { value: "batch", label: "Batch" },
+ *     { value: "fast",  label: "Fast" },
+ *   ]}
+ * />
+ * ```
+ */
+export default function RadioGroup<T extends string = string>({
+  options,
+  value,
+  onChange,
+  disabled = false,
+  ariaLabel,
+  className = "",
+}: RadioGroupProps<T>) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className={`inline-flex rounded-full p-1 bg-accent-primary/10 ${className}`}
+    >
+      {options.map((opt) => {
+        const isSelected = opt.value === value;
+        const isDisabled = disabled || opt.disabled;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            data-selected={isSelected}
+            onClick={() => onChange(opt.value)}
+            disabled={isDisabled}
+            title={opt.title}
+            className="inline-flex items-center gap-1.5 px-4 py-1.5 text-xs font-semibold rounded-full transition-colors cursor-pointer text-accent-primary/70 hover:text-accent-primary data-[selected=true]:bg-accent-primary data-[selected=true]:text-white data-[selected=true]:shadow-[0_1px_2px_rgba(0,0,0,0.12)] data-[selected=true]:hover:bg-accent-hover disabled:cursor-not-allowed disabled:text-text-secondary/40 disabled:hover:text-white"
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/components/ui/RadioGroup.tsx
+++ b/app/components/ui/RadioGroup.tsx
@@ -19,8 +19,6 @@ export interface RadioGroupProps<T extends string = string> {
 }
 
 /**
- * Generic over the value type so consumers get type-safe `onChange` callbacks:
- *
  * ```tsx
  * <RadioGroup<"batch" | "fast">
  *   value={runMode}

--- a/app/components/ui/index.ts
+++ b/app/components/ui/index.ts
@@ -4,7 +4,6 @@ export { default as Select } from "./Select";
 export { default as MultiSelect } from "./MultiSelect";
 export { default as Modal } from "./Modal";
 export { default as RadioGroup } from "./RadioGroup";
-export type { RadioGroupOption, RadioGroupProps } from "./RadioGroup";
 export { default as Loader, LoaderBox } from "./Loader";
 export { default as InfoTooltip } from "./InfoTooltip";
 export { default as Tag } from "./Tag";

--- a/app/components/ui/index.ts
+++ b/app/components/ui/index.ts
@@ -3,6 +3,8 @@ export { default as Field } from "./Field";
 export { default as Select } from "./Select";
 export { default as MultiSelect } from "./MultiSelect";
 export { default as Modal } from "./Modal";
+export { default as RadioGroup } from "./RadioGroup";
+export type { RadioGroupOption, RadioGroupProps } from "./RadioGroup";
 export { default as Loader, LoaderBox } from "./Loader";
 export { default as InfoTooltip } from "./InfoTooltip";
 export { default as Tag } from "./Tag";

--- a/app/lib/types/dataset.ts
+++ b/app/lib/types/dataset.ts
@@ -7,6 +7,7 @@ export interface Dataset {
   duplication_factor: number;
   langfuse_dataset_id: string;
   object_store_url: string;
+  eligible_for_fast?: boolean;
 }
 
 export interface ViewDatasetModalData {

--- a/app/lib/types/evaluation.ts
+++ b/app/lib/types/evaluation.ts
@@ -123,9 +123,12 @@ export interface EvalCost {
   total_cost_usd: number;
 }
 
+export type RunMode = "batch" | "fast";
+
 export interface EvalJob {
   id: number;
   run_name: string;
+  run_mode?: RunMode;
   dataset_name: string;
   dataset_id: number;
   batch_job_id: number;


### PR DESCRIPTION
### Issue: https://github.com/ProjectTech4DevAI/kaapi-frontend/issues/204

### Summary:
- **Run mode selection:** Users can now toggle between `batch` and `fast` evaluation modes. The backend receives `run_mode: fast` only when applicable (backward-compatible). Default evals is go under the `Batch` processing.
- **Eligibility validation:** Fast mode requires smaller datasets; the run button is gated on a new `eligible_for_fast` dataset flag, with clearer error messaging for dataset-size limits.
- Replaces the inline segmented-control buttons (e.g. export format selection) with a generic radio group.
- New RunMode ("batch" | "fast") type and an `eligible_for_fast` property on the dataset type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Run Mode selection (Batch/Fast) available when creating evaluations with dataset eligibility checks
  * Redesigned export format selector with clearer option labels (Individual Rows, Group by Questions)
  * Visual run mode badges now display on evaluation reports and cards

* **Improvements**
  * Enhanced error messages for evaluation creation, including dataset compatibility checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->