### PR TITLE
 Assessment: Anthropic Claude model list and configuration

### DIFF
--- a/app/lib/data/assessmentModels.ts
+++ b/app/lib/data/assessmentModels.ts
@@ -52,6 +52,23 @@ const GEMINI_THINKING_NO_MINIMAL_CONFIG = {
   },
 } as const satisfies Record<string, ConfigParamDefinition>;
 
+const ANTHROPIC_MODEL_CONFIG = {
+  top_p: {
+    max: 1.0,
+    min: 0.0,
+    type: "float",
+    default: 1.0,
+    description: "Nucleus sampling. Use either this or temperature, not both.",
+  },
+  temperature: {
+    max: 1.0,
+    min: 0.0,
+    type: "float",
+    default: 1.0,
+    description: "Controls randomness. Lower = more deterministic.",
+  },
+} as const satisfies Record<string, ConfigParamDefinition>;
+
 export const ASSESSMENT_MODEL_CONFIGS: AssessmentModelConfig[] = [
   // OpenAI
   { provider: "openai", model_name: "gpt-4o-mini", config: GPT4_STYLE_CONFIG },
@@ -288,11 +305,22 @@ export const ASSESSMENT_MODEL_CONFIGS: AssessmentModelConfig[] = [
     model_name: "gemini-3-flash-preview",
     config: GEMINI_THINKING_CONFIG,
   },
+  {
+    provider: "anthropic",
+    model_name: "claude-haiku-4-5",
+    config: ANTHROPIC_MODEL_CONFIG,
+  },
+  {
+    provider: "anthropic",
+    model_name: "claude-sonnet-4-6",
+    config: ANTHROPIC_MODEL_CONFIG,
+  },
 ];
 
 export const PROVIDER_OPTIONS = [
   { value: "openai", label: "OpenAI" },
   { value: "google", label: "Google (Gemini)" },
+  { value: "anthropic", label: "Anthropic (Claude)" },
 ] as const;
 
 export function getModelsByProvider(provider: string): ModelOption[] {

--- a/app/lib/types/assessment.ts
+++ b/app/lib/types/assessment.ts
@@ -132,7 +132,7 @@ export interface ConfigParamDefinition {
 }
 
 export interface AssessmentModelConfig {
-  provider: "openai" | "google";
+  provider: "openai" | "google" | "anthropic";
   model_name: string;
   config: Record<string, ConfigParamDefinition>;
 }


### PR DESCRIPTION
### Issue: https://github.com/ProjectTech4DevAI/kaapi-frontend/issues/206

### Summary

- **Assessment Models:** Added Anthropic as a selectable provider in the assessment configuration. Users can now run assessments with `claude-sonnet-4-6` and `claude-haiku-4-5`, configurable via a new `ANTHROPIC_MODEL_CONFIG` preset (`temperature` and `top_p`, both 0.0–1.0 with default 1.0, with guidance to use one or the other).
- **Provider picker:** "Anthropic (Claude)" now appears in the provider dropdown (`PROVIDER_OPTIONS`) alongside OpenAI and Google (Gemini).
- Minor cleanup: extended the `AssessmentModelConfig` provider union in `app/lib/types/assessment.ts` to include `"anthropic"`.