### PR TITLE
Config: Remove the GPT-5.4-Pro Model and UI Updates

### DIFF
--- a/app/components/evaluations/CreateDatasetForm.tsx
+++ b/app/components/evaluations/CreateDatasetForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Button, Field, Select } from "@/app/components/ui";
+import { Button, Field, InfoTooltip, Select } from "@/app/components/ui";
 import {
   CheckLineIcon,
   CloseIcon,
@@ -41,10 +41,6 @@ export default function CreateDatasetForm({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [showDuplicationInfo, setShowDuplicationInfo] = useState(false);
-  const [duplicationInfoPos, setDuplicationInfoPos] = useState({
-    top: 0,
-    left: 0,
-  });
 
   useEffect(() => {
     if (!showDuplicationInfo) return;
@@ -104,44 +100,19 @@ export default function CreateDatasetForm({
 
       <div>
         <label className="text-xs font-medium mb-1.5 text-text-secondary">
-          <span className="inline-flex items-center gap-1">
+          <span className="inline-flex items-center">
             Duplication Factor
-            <span
-              className="inline-flex items-center justify-center w-3.5 h-3.5 rounded-full text-[9px] font-normal cursor-pointer shrink-0 bg-bg-primary border border-border text-text-secondary"
-              onClick={(e) => {
-                e.stopPropagation();
-                e.preventDefault();
-                const rect = e.currentTarget.getBoundingClientRect();
-                setDuplicationInfoPos({
-                  top: rect.bottom + 4,
-                  left: rect.left,
-                });
-                setShowDuplicationInfo(!showDuplicationInfo);
-              }}
-            >
-              i
-            </span>
-            {showDuplicationInfo && (
-              <div
-                className="fixed z-50 rounded-lg shadow-lg border text-xs p-3 bg-bg-primary border-border w-[280px]"
-                style={{
-                  top: duplicationInfoPos.top,
-                  left: duplicationInfoPos.left,
-                }}
-                onClick={(e) => e.stopPropagation()}
-              >
-                <div className="font-semibold mb-1 text-text-primary">
-                  Duplication Factor
-                </div>
-                <p className="text-text-secondary leading-relaxed">
+            <InfoTooltip
+              text={
+                <>
                   Controls how many times each question is sent to the AI to
                   generate an answer. For example, setting this to 3 means the
                   AI answers each question 3 separate times — helpful for
                   checking if the AI gives consistent and reliable responses
                   each time.
-                </p>
-              </div>
-            )}
+                </>
+              }
+            />
           </span>
         </label>
         <Select

--- a/app/components/evaluations/CreateDatasetForm.tsx
+++ b/app/components/evaluations/CreateDatasetForm.tsx
@@ -168,12 +168,15 @@ export default function CreateDatasetForm({
         />
 
         {uploadedFile ? (
-          <div className="rounded-lg p-3 bg-bg-secondary">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2.5">
+          <div className="rounded-lg p-3 bg-bg-secondary overflow-hidden">
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2.5 flex-1 min-w-0">
                 <CheckLineIcon className="w-4 h-4 shrink-0 text-status-success" />
-                <div>
-                  <p className="text-sm font-medium text-text-primary">
+                <div className="min-w-0 flex-1">
+                  <p
+                    className="text-sm font-medium text-text-primary truncate"
+                    title={uploadedFile.name}
+                  >
                     {uploadedFile.name}
                   </p>
                   <p className="text-xs text-text-secondary">
@@ -186,7 +189,7 @@ export default function CreateDatasetForm({
                   onRemoveFile();
                   if (fileInputRef.current) fileInputRef.current.value = "";
                 }}
-                className="p-1 rounded text-text-secondary cursor-pointer"
+                className="p-1 rounded text-text-secondary cursor-pointer shrink-0"
                 aria-label="Remove file"
               >
                 <CloseIcon className="w-4 h-4" />

--- a/app/components/evaluations/CreateDatasetForm.tsx
+++ b/app/components/evaluations/CreateDatasetForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { Button, Field, InfoTooltip, Select } from "@/app/components/ui";
 import {
   CheckLineIcon,
@@ -40,19 +40,6 @@ export default function CreateDatasetForm({
 }: CreateDatasetFormProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isDragging, setIsDragging] = useState(false);
-  const [showDuplicationInfo, setShowDuplicationInfo] = useState(false);
-
-  useEffect(() => {
-    if (!showDuplicationInfo) return;
-    const handleClick = () => setShowDuplicationInfo(false);
-    const handleScroll = () => setShowDuplicationInfo(false);
-    document.addEventListener("click", handleClick);
-    window.addEventListener("scroll", handleScroll, true);
-    return () => {
-      document.removeEventListener("click", handleClick);
-      window.removeEventListener("scroll", handleScroll, true);
-    };
-  }, [showDuplicationInfo]);
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();

--- a/app/components/evaluations/CreateDatasetForm.tsx
+++ b/app/components/evaluations/CreateDatasetForm.tsx
@@ -7,6 +7,7 @@ import {
   CloseIcon,
   CloudUploadIcon,
 } from "@/app/components/icons";
+import { MAX_NAME_LENGTH } from "@/app/lib/constants";
 
 interface CreateDatasetFormProps {
   datasetName: string;
@@ -91,6 +92,7 @@ export default function CreateDatasetForm({
         value={datasetName}
         onChange={setDatasetName}
         placeholder="e.g., QnA Dataset v1"
+        maxLength={MAX_NAME_LENGTH}
       />
 
       <Field

--- a/app/components/evaluations/RunEvaluationForm.tsx
+++ b/app/components/evaluations/RunEvaluationForm.tsx
@@ -12,6 +12,7 @@ import { CheckCircleIcon, PlayIcon } from "@/app/components/icons";
 import ConfigSelector from "@/app/components/ConfigSelector";
 import EvalDatasetDescription from "./EvalDatasetDescription";
 import { RunMode, Tab } from "@/app/lib/types/evaluation";
+import { MAX_NAME_LENGTH } from "@/app/lib/constants";
 
 interface RunEvaluationFormProps {
   storedDatasets: Dataset[];
@@ -73,6 +74,7 @@ export default function RunEvaluationForm({
           placeholder="e.g., test_run_1"
           disabled={isEvaluating}
           error={nameError}
+          maxLength={MAX_NAME_LENGTH}
         />
       </div>
 
@@ -117,11 +119,11 @@ export default function RunEvaluationForm({
       </div>
 
       {selectedDataset && (
-        <div className="border rounded-lg p-3 border-status-success bg-green-600/2">
+        <div className="border rounded-lg p-3 border-status-success bg-green-600/2 overflow-hidden">
           <div className="flex items-start gap-2">
             <CheckCircleIcon className="w-5 h-5 shrink-0 mt-0.5 text-status-success" />
-            <div className="flex-1">
-              <div className="text-sm font-medium text-text-primary">
+            <div className="flex-1 min-w-0">
+              <div className="text-sm font-medium text-text-primary wrap-anywhere">
                 {selectedDataset.dataset_name}
               </div>
               {selectedDataset.description && (

--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -30,6 +30,8 @@ export const CACHE_MAX_AGE_MS = 5 * 60 * 1000;
 
 export const DEFAULT_PAGE_LIMIT = 10;
 
+export const MAX_NAME_LENGTH = 64;
+
 export const ACCEPTED_DOCUMENT_TYPES =
   ".pdf,.doc,.docx,.txt,.jpg,.jpeg,.png,.gif,.bmp,.webp";
 

--- a/app/lib/models.ts
+++ b/app/lib/models.ts
@@ -9,7 +9,6 @@ export interface ModelOption {
 export const MODEL_OPTIONS: Record<string, ModelOption[]> = {
   openai: [
     { value: "gpt-5.4", label: "GPT-5.4" },
-    { value: "gpt-5.4-pro", label: "GPT-5.4 Pro" },
     { value: "gpt-5.4-mini", label: "GPT-5.4 Mini" },
     { value: "gpt-5.4-nano", label: "GPT-5.4 Nano" },
     { value: "gpt-5", label: "GPT-5" },


### PR DESCRIPTION
### Issue:
Closes: https://github.com/ProjectTech4DevAI/kaapi-frontend/issues/214

### Type:
type: fix

### Summary:
- Removed the `GPT-5.4-Pro` model from the config.
- Added the `maxLength` limit in Name field on Dataset and Evals form.
- Fixed the breaking UI in dataset and evals form while choosing the large name document.
- Use the `InfoTooltip` component instead of hard-coding tooltip code.