### PR TITLE
Assessment: Make user prompt optional & support attachment column mapping

### DIFF
--- a/app/(main)/assessment/page.tsx
+++ b/app/(main)/assessment/page.tsx
@@ -168,12 +168,11 @@ function PageContent() {
       showToastError("Dataset is required");
       return;
     }
-    if (columnMapping.textColumns.length === 0) {
-      showToastError("Map at least one text column");
-      return;
-    }
-    if (!promptTemplate.trim()) {
-      showToastError("Prompt is required");
+    if (
+      columnMapping.textColumns.length === 0 &&
+      columnMapping.attachments.length === 0
+    ) {
+      showToastError("Map at least one text or attachment column");
       return;
     }
     if (!outputSchema.some((field) => field.name.trim())) {
@@ -271,17 +270,16 @@ function PageContent() {
   };
 
   const hasDataset = !!datasetId && columns.length > 0;
-  const hasMapperSelection = columnMapping.textColumns.length > 0;
-  const hasPromptTemplate = promptTemplate.trim().length > 0;
+  const hasMapperSelection =
+    columnMapping.textColumns.length > 0 ||
+    columnMapping.attachments.length > 0;
   const hasConfiguredResponseFormat = outputSchema.some((field) =>
     field.name.trim(),
   );
-  const canReachReview =
-    hasPromptTemplate && configs.length > 0 && hasConfiguredResponseFormat;
+  const canReachReview = configs.length > 0 && hasConfiguredResponseFormat;
   const canSubmitAssessment =
     !!datasetId &&
     hasMapperSelection &&
-    hasPromptTemplate &&
     hasConfiguredResponseFormat &&
     configs.length > 0 &&
     experimentName.trim().length > 0 &&
@@ -289,16 +287,14 @@ function PageContent() {
   const submitBlockerMessage = !datasetId
     ? "Select a dataset to submit"
     : !hasMapperSelection
-      ? "Map at least one text column to submit"
-      : !hasPromptTemplate
-        ? "Write a prompt to submit"
-        : !hasConfiguredResponseFormat
-          ? "Set response format to submit"
-          : configs.length === 0
-            ? "Select at least one configuration to submit"
-            : !experimentName.trim()
-              ? "Enter an experiment name to submit"
-              : "";
+      ? "Map at least one text or attachment column to submit"
+      : !hasConfiguredResponseFormat
+        ? "Set response format to submit"
+        : configs.length === 0
+          ? "Select at least one configuration to submit"
+          : !experimentName.trim()
+            ? "Enter an experiment name to submit"
+            : "";
   const effectiveCompletedConfigSteps = useMemo(() => {
     const merged = new Set(completedConfigSteps);
     if (hasMapperSelection) merged.add(1);

--- a/app/api/assessment/runs/[run_id]/post-processing/route.ts
+++ b/app/api/assessment/runs/[run_id]/post-processing/route.ts
@@ -1,0 +1,27 @@
+// BFF proxy — PATCH /api/v1/assessment/runs/:id/post-processing
+import { NextRequest } from "next/server";
+import { proxyErrorResponse, proxyJsonResponse } from "@/app/api/_routeProxy";
+import type { RouteContext } from "@/app/lib/types/assessment";
+
+export async function PATCH(
+  request: NextRequest,
+  context: RouteContext<"run_id">,
+) {
+  try {
+    const { run_id } = await context.params;
+    const body = await request.json();
+    return await proxyJsonResponse(
+      request,
+      `/api/v1/assessment/runs/${run_id}/post-processing`,
+      {
+        method: "PATCH",
+        body: JSON.stringify(body),
+      },
+    );
+  } catch (error: unknown) {
+    return proxyErrorResponse(
+      "Assessment run post-processing proxy error:",
+      error,
+    );
+  }
+}

--- a/app/components/assessment/ColumnMapperStep.tsx
+++ b/app/components/assessment/ColumnMapperStep.tsx
@@ -137,7 +137,9 @@ export default function ColumnMapperStep({
   const mappedCount = columnConfigs.filter(
     (config) => config.role !== "unmapped",
   ).length;
-  const hasText = columnConfigs.some((config) => config.role === "text");
+  const hasMappedColumn = columnConfigs.some(
+    (config) => config.role === "text" || config.role === "attachment",
+  );
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col">
@@ -383,17 +385,17 @@ export default function ColumnMapperStep({
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
             <span
               className={`text-xs ${
-                hasText ? "text-text-secondary" : "text-status-warning"
+                hasMappedColumn ? "text-text-secondary" : "text-status-warning"
               }`}
             >
-              {hasText
+              {hasMappedColumn
                 ? "Ready to continue."
-                : "Select at least one Text column."}
+                : "Map at least one Text or Attachment column."}
             </span>
             <Button
               type="button"
               onClick={handleNext}
-              disabled={!hasText}
+              disabled={!hasMappedColumn}
               className="!rounded-lg"
             >
               Next: Eliminatory

--- a/app/components/assessment/PrefilterStep.tsx
+++ b/app/components/assessment/PrefilterStep.tsx
@@ -85,9 +85,11 @@ export default function PrefilterStep({
   );
   const [isPromptModalOpen, setIsPromptModalOpen] = useState(false);
 
+  const trHasColumns = trColumns.length > 0 || trAttachmentColumns.length > 0;
+
   const handleNext = () => {
     const config: PrefilterConfig = {};
-    if (trEnabled && trColumns.length > 0 && trPrompt.trim()) {
+    if (trEnabled && trHasColumns && trPrompt.trim()) {
       config.topic_relevance = {
         columns: trColumns,
         prompt: trPrompt.trim(),
@@ -103,7 +105,7 @@ export default function PrefilterStep({
     onNext();
   };
 
-  const trValid = !trEnabled || (trColumns.length > 0 && !!trPrompt.trim());
+  const trValid = !trEnabled || (trHasColumns && !!trPrompt.trim());
   const dupValid = !dupEnabled || dupColumns.length > 0;
   const canProceed = trValid && dupValid;
 
@@ -142,16 +144,18 @@ export default function PrefilterStep({
               <div>
                 <label className="mb-2 block text-xs font-medium text-text-secondary">
                   Columns to evaluate
-                  <span className="ml-1 text-status-error-text">*</span>
+                  {attachmentColumns.length === 0 && (
+                    <span className="ml-1 text-status-error-text">*</span>
+                  )}
                 </label>
                 <ColumnChips
                   columns={columns}
                   selected={trColumns}
                   onChange={setTrColumns}
                 />
-                {trColumns.length === 0 && (
+                {trColumns.length === 0 && trAttachmentColumns.length === 0 && (
                   <p className="mt-1.5 text-xs text-status-warning">
-                    Select at least one column.
+                    Select at least one text or document column.
                   </p>
                 )}
                 {trColumns.length > 0 && (

--- a/app/components/assessment/PromptAndConfigStep.tsx
+++ b/app/components/assessment/PromptAndConfigStep.tsx
@@ -26,7 +26,11 @@ import {
   type PromptAndConfigStepProps,
   type VersionListState,
 } from "@/app/lib/types/assessment";
-import type { ConfigBlob, ConfigPublic } from "@/app/lib/types/configs";
+import type {
+  CompletionConfig,
+  ConfigBlob,
+  ConfigPublic,
+} from "@/app/lib/types/configs";
 import useLatestConfigModels from "@/app/hooks/useLatestConfigModels";
 import AssessmentConfiguration from "./prompt-config/AssessmentConfiguration";
 import SetupProgress from "./prompt-config/SetupProgress";
@@ -93,13 +97,10 @@ export default function PromptAndConfigStep({
     [promptTemplate, textColumns],
   );
   const namedSchemaFields = outputSchema.filter((field) => field.name.trim());
-  const hasPromptTemplate = promptTemplate.trim().length > 0;
   const hasConfiguredResponseFormat = namedSchemaFields.length > 0;
-  const canProceed =
-    hasPromptTemplate && configs.length > 0 && hasConfiguredResponseFormat;
-  const nextBlockerMessage = !hasPromptTemplate
-    ? "Write a prompt to continue"
-    : configs.length === 0
+  const canProceed = configs.length > 0 && hasConfiguredResponseFormat;
+  const nextBlockerMessage =
+    configs.length === 0
       ? "Select at least one configuration to continue"
       : !hasConfiguredResponseFormat
         ? "Set response format to continue"
@@ -299,7 +300,7 @@ export default function PromptAndConfigStep({
     }));
   };
 
-  const handleProviderChange = (provider: "openai") => {
+  const handleProviderChange = (provider: CompletionConfig["provider"]) => {
     const defaultModel = getDefaultModelForProvider(provider);
     setDraft((prev) => ({
       ...prev,

--- a/app/components/assessment/prompt-config/ConfigCreator.tsx
+++ b/app/components/assessment/prompt-config/ConfigCreator.tsx
@@ -6,6 +6,7 @@ import type {
   ModelOption,
   ValueSetter,
 } from "@/app/lib/types/assessment";
+import type { CompletionConfig } from "@/app/lib/types/configs";
 import ConfigParamControl from "./ConfigParamControl";
 
 export interface ConfigCreatorProps {
@@ -19,7 +20,7 @@ export interface ConfigCreatorProps {
   isSaving: boolean;
   setConfigName: ValueSetter<string>;
   setCommitMessage: ValueSetter<string>;
-  onProviderChange: ValueSetter<"openai">;
+  onProviderChange: ValueSetter<CompletionConfig["provider"]>;
   onModelChange: ValueSetter<string>;
   onParamChange: (key: string, value: string | number) => void;
   onSave: () => void | Promise<void>;
@@ -56,7 +57,9 @@ export default function ConfigCreator({
           </label>
           <Select
             value={currentProvider}
-            onChange={(e) => onProviderChange(e.target.value as "openai")}
+            onChange={(e) =>
+              onProviderChange(e.target.value as CompletionConfig["provider"])
+            }
             className={selectClass}
             options={[...PROVIDER_OPTIONS]}
           />

--- a/app/components/assessment/prompt-config/UserPrompt.tsx
+++ b/app/components/assessment/prompt-config/UserPrompt.tsx
@@ -41,6 +41,9 @@ export default function UserPrompt({
           <span className="text-base font-semibold text-text-primary">
             User prompt
           </span>
+          <span className="rounded-full bg-bg-secondary px-2 py-0.5 text-[10px] font-medium text-text-secondary">
+            Optional
+          </span>
         </Button>
         <InfoTooltip
           text={

--- a/app/lib/data/assessmentModels.ts
+++ b/app/lib/data/assessmentModels.ts
@@ -266,42 +266,42 @@ export const ASSESSMENT_MODEL_CONFIGS: AssessmentModelConfig[] = [
   },
   // Google (Gemini)
   {
-    provider: "google",
+    provider: "google-aistudio",
     model_name: "gemini-2.0-flash-lite",
     config: GEMINI_TEMPERATURE_CONFIG,
   },
   {
-    provider: "google",
+    provider: "google-aistudio",
     model_name: "gemini-2.0-flash",
     config: GEMINI_TEMPERATURE_CONFIG,
   },
   {
-    provider: "google",
+    provider: "google-aistudio",
     model_name: "gemini-2.5-flash-lite",
     config: GEMINI_TEMPERATURE_CONFIG,
   },
   {
-    provider: "google",
+    provider: "google-aistudio",
     model_name: "gemini-2.5-flash",
     config: GEMINI_TEMPERATURE_CONFIG,
   },
   {
-    provider: "google",
+    provider: "google-aistudio",
     model_name: "gemini-2.5-pro",
     config: GEMINI_TEMPERATURE_CONFIG,
   },
   {
-    provider: "google",
+    provider: "google-aistudio",
     model_name: "gemini-3.1-flash-lite",
     config: GEMINI_THINKING_CONFIG,
   },
   {
-    provider: "google",
+    provider: "google-aistudio",
     model_name: "gemini-3.1-pro-preview",
     config: GEMINI_THINKING_NO_MINIMAL_CONFIG,
   },
   {
-    provider: "google",
+    provider: "google-aistudio",
     model_name: "gemini-3-flash-preview",
     config: GEMINI_THINKING_CONFIG,
   },
@@ -319,7 +319,7 @@ export const ASSESSMENT_MODEL_CONFIGS: AssessmentModelConfig[] = [
 
 export const PROVIDER_OPTIONS = [
   { value: "openai", label: "OpenAI" },
-  { value: "google", label: "Google (Gemini)" },
+  { value: "google-aistudio", label: "Google (Gemini)" },
   { value: "anthropic", label: "Anthropic (Claude)" },
 ] as const;
 

--- a/app/lib/types/assessment.ts
+++ b/app/lib/types/assessment.ts
@@ -132,7 +132,7 @@ export interface ConfigParamDefinition {
 }
 
 export interface AssessmentModelConfig {
-  provider: "openai" | "google" | "anthropic";
+  provider: "openai" | "google" | "google-aistudio" | "anthropic";
   model_name: string;
   config: Record<string, ConfigParamDefinition>;
 }

--- a/app/lib/types/configs.ts
+++ b/app/lib/types/configs.ts
@@ -74,7 +74,7 @@ export interface CompletionParams {
 }
 
 export interface CompletionConfig {
-  provider: "openai" | "google";
+  provider: "openai" | "google" | "google-aistudio" | "anthropic";
   type?: "text" | "stt" | "tts";
   params: CompletionParams;
 }


### PR DESCRIPTION
## Issue

Closes #227 

## Summary
- Made the user prompt optional in the assessment flow — added an "Optional" badge and removed the prompt-required validation and step gating.
- Allowed attachment/document columns to satisfy column mapping, the topic-relevance prefilter, and submit validation (previously required at least one text column).
- Renamed provider `google` → `google-aistudio` and added `anthropic` to the provider type unions to match the backend.
- Replaced hardcoded `"openai"` provider literals with `CompletionConfig["provider"]`.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `npm run dev` and `npm run build` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested