### PR TITLE
feat(security): Move API Key to Cookies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ function MyComponent() {
   const {
     isAuthenticated, isHydrated,
     session, currentUser, googleProfile,
-    apiKeys, activeKey, addKey, removeKey, setKeys,
+    apiKeys, activeKey, addKey, removeKey,
     loginWithToken, logout,
   } = useAuth();
 }

--- a/app/(main)/keystore/page.tsx
+++ b/app/(main)/keystore/page.tsx
@@ -13,8 +13,6 @@ import AddKeyModal from "@/app/components/keystore/AddKeyModal";
 import { useAuth } from "@/app/lib/context/AuthContext";
 import { useApp } from "@/app/lib/context/AppContext";
 import { useToast } from "@/app/hooks/useToast";
-import { apiFetch } from "@/app/lib/apiClient";
-import { APIKey } from "@/app/lib/types/credentials";
 
 export default function KaapiKeystore() {
   const { sidebarCollapsed } = useApp();
@@ -25,8 +23,6 @@ export default function KaapiKeystore() {
   const [newKeyLabel, setNewKeyLabel] = useState("");
   const [newKeyValue, setNewKeyValue] = useState("");
   const [newKeyProvider, setNewKeyProvider] = useState("Kaapi");
-  const [visibleKeys, setVisibleKeys] = useState<Set<string>>(new Set());
-  const [copiedKeyId, setCopiedKeyId] = useState<string | null>(null);
   const [isValidating, setIsValidating] = useState(false);
 
   const resetForm = () => {
@@ -41,61 +37,31 @@ export default function KaapiKeystore() {
       return;
     }
 
-    const trimmedKey = newKeyValue.trim();
     setIsValidating(true);
-
-    try {
-      await apiFetch("/api/apikeys/verify", trimmedKey);
-    } catch (err) {
-      console.error("API key validation failed:", err);
-      toast.error("Invalid API key. Please check the key and try again.");
-      setIsValidating(false);
-      return;
-    }
-
-    const newKey: APIKey = {
-      id: Date.now().toString(),
+    const newKey = {
+      key: newKeyValue.trim(),
       label: newKeyLabel.trim(),
-      key: trimmedKey,
       provider: newKeyProvider,
-      createdAt: new Date().toISOString(),
     };
-
-    addKey(newKey);
-    resetForm();
-    setIsModalOpen(false);
-    setIsValidating(false);
-    toast.success("API key added successfully");
-  };
-
-  const handleDeleteKey = (id: string) => {
-    removeApiKey(id);
-    setVisibleKeys((prev) => {
-      const next = new Set(prev);
-      next.delete(id);
-      return next;
-    });
-    toast.success("API key removed");
-  };
-
-  const toggleKeyVisibility = (id: string) => {
-    setVisibleKeys((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  };
-
-  const copyToClipboard = async (text: string, id: string) => {
     try {
-      await navigator.clipboard.writeText(text);
-      setCopiedKeyId(id);
-      toast.success("API key copied to clipboard");
-      setTimeout(() => setCopiedKeyId(null), 1500);
-    } catch {
-      toast.error("Failed to copy API key");
+      await addKey(newKey);
+      resetForm();
+      setIsModalOpen(false);
+      toast.success("API key added successfully");
+    } catch (err) {
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : "Invalid API key. Please check the key and try again.",
+      );
+    } finally {
+      setIsValidating(false);
     }
+  };
+
+  const handleDeleteKey = async (id: string) => {
+    await removeApiKey(id);
+    toast.success("API key removed");
   };
 
   const closeAddModal = () => {
@@ -118,10 +84,6 @@ export default function KaapiKeystore() {
             <div className="max-w-3xl mx-auto">
               <KeysCard
                 apiKeys={apiKeys}
-                visibleKeys={visibleKeys}
-                copiedKeyId={copiedKeyId}
-                onToggleVisibility={toggleKeyVisibility}
-                onCopy={copyToClipboard}
                 onDelete={handleDeleteKey}
                 onAddNew={() => setIsModalOpen(true)}
               />

--- a/app/(main)/keystore/page.tsx
+++ b/app/(main)/keystore/page.tsx
@@ -22,13 +22,11 @@ export default function KaapiKeystore() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [newKeyLabel, setNewKeyLabel] = useState("");
   const [newKeyValue, setNewKeyValue] = useState("");
-  const [newKeyProvider, setNewKeyProvider] = useState("Kaapi");
   const [isValidating, setIsValidating] = useState(false);
 
   const resetForm = () => {
     setNewKeyLabel("");
     setNewKeyValue("");
-    setNewKeyProvider("Kaapi");
   };
 
   const handleAddKey = async () => {
@@ -38,13 +36,8 @@ export default function KaapiKeystore() {
     }
 
     setIsValidating(true);
-    const newKey = {
-      key: newKeyValue.trim(),
-      label: newKeyLabel.trim(),
-      provider: newKeyProvider,
-    };
     try {
-      await addKey(newKey);
+      await addKey({ key: newKeyValue.trim(), label: newKeyLabel.trim() });
       resetForm();
       setIsModalOpen(false);
       toast.success("API key added successfully");
@@ -96,11 +89,9 @@ export default function KaapiKeystore() {
         open={isModalOpen}
         newKeyLabel={newKeyLabel}
         newKeyValue={newKeyValue}
-        newKeyProvider={newKeyProvider}
         isValidating={isValidating}
         onLabelChange={setNewKeyLabel}
         onValueChange={setNewKeyValue}
-        onProviderChange={setNewKeyProvider}
         onAddKey={handleAddKey}
         onClose={closeAddModal}
       />

--- a/app/api/apikeys/route.ts
+++ b/app/api/apikeys/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { apiClient } from "@/app/lib/apiClient";
+import { clearApiKeyCookies, setApiKeyCookies } from "@/app/lib/authCookie";
+import type { AddApiKeyRequest, ApiKeyMeta } from "@/app/lib/types/credentials";
+
+function maskKey(key: string): string {
+  const tail = key.slice(-4);
+  return `${"•".repeat(8)}${tail}`;
+}
+
+export async function POST(request: NextRequest) {
+  let body: AddApiKeyRequest;
+  try {
+    body = (await request.json()) as AddApiKeyRequest;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 },
+    );
+  }
+
+  const key = body.key?.trim();
+  const label = body.label?.trim();
+  const provider = body.provider?.trim() || "Kaapi";
+
+  if (!key || !label) {
+    return NextResponse.json(
+      { error: "Both a label and an API key are required" },
+      { status: 400 },
+    );
+  }
+
+  const verifyRequest = new Request(request.url, {
+    headers: {
+      "X-API-KEY": key,
+      Cookie: request.headers.get("Cookie") || "",
+    },
+  });
+
+  let status: number;
+  try {
+    ({ status } = await apiClient(verifyRequest, "/api/v1/apikeys/verify"));
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to reach backend for API key verification" },
+      { status: 502 },
+    );
+  }
+
+  if (status < 200 || status >= 300) {
+    return NextResponse.json(
+      { error: "Invalid API key. Please check the key and try again." },
+      { status: 401 },
+    );
+  }
+
+  const meta: ApiKeyMeta = {
+    id: crypto.randomUUID(),
+    label,
+    provider,
+    masked: maskKey(key),
+    createdAt: new Date().toISOString(),
+  };
+
+  const res = NextResponse.json({ data: meta }, { status: 200 });
+  setApiKeyCookies(res, key, meta);
+  return res;
+}
+
+export async function DELETE() {
+  const res = NextResponse.json({ success: true }, { status: 200 });
+  clearApiKeyCookies(res);
+  return res;
+}

--- a/app/api/apikeys/route.ts
+++ b/app/api/apikeys/route.ts
@@ -21,7 +21,6 @@ export async function POST(request: NextRequest) {
 
   const key = body.key?.trim();
   const label = body.label?.trim();
-  const provider = body.provider?.trim() || "Kaapi";
 
   if (!key || !label) {
     return NextResponse.json(
@@ -57,7 +56,6 @@ export async function POST(request: NextRequest) {
   const meta: ApiKeyMeta = {
     id: crypto.randomUUID(),
     label,
-    provider,
     masked: maskKey(key),
     createdAt: new Date().toISOString(),
   };

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,6 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { apiClient } from "@/app/lib/apiClient";
-import { clearFeaturesCookie, clearRoleCookie } from "@/app/lib/authCookie";
+import {
+  clearApiKeyCookies,
+  clearFeaturesCookie,
+  clearRoleCookie,
+} from "@/app/lib/authCookie";
 
 export async function POST(request: NextRequest) {
   const { status, data, headers } = await apiClient(
@@ -18,6 +22,7 @@ export async function POST(request: NextRequest) {
 
   clearRoleCookie(res);
   clearFeaturesCookie(res);
+  clearApiKeyCookies(res);
 
   return res;
 }

--- a/app/api/evaluations/stt/runs/route.ts
+++ b/app/api/evaluations/stt/runs/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { apiClient } from "@/app/lib/apiClient";
+import { apiClient, getRequestApiKey } from "@/app/lib/apiClient";
 
 export async function GET(request: Request) {
   try {
@@ -18,7 +18,7 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    const apiKey = request.headers.get("X-API-KEY");
+    const apiKey = getRequestApiKey(request);
     if (!apiKey) {
       return NextResponse.json(
         {

--- a/app/components/keystore/AddKeyModal.tsx
+++ b/app/components/keystore/AddKeyModal.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Button, Field, Modal, Select } from "@/app/components/ui";
-import { InfoIcon } from "@/app/components/icons";
 
 const PROVIDERS = [{ value: "Kaapi", label: "Kaapi" }];
 
@@ -72,15 +71,6 @@ export default function AddKeyModal({
             onChange={onValueChange}
             placeholder="Paste your API key here"
           />
-        </div>
-
-        <div className="mt-5 rounded-md p-3 bg-accent-primary/5 border border-accent-primary/20">
-          <div className="flex gap-2">
-            <InfoIcon className="w-4 h-4 shrink-0 mt-0.5 text-accent-primary" />
-            <p className="text-xs text-text-secondary">
-              API keys are stored in your browser&apos;s local storage.
-            </p>
-          </div>
         </div>
       </div>
 

--- a/app/components/keystore/AddKeyModal.tsx
+++ b/app/components/keystore/AddKeyModal.tsx
@@ -1,18 +1,15 @@
 "use client";
 
-import { Button, Field, Modal, Select } from "@/app/components/ui";
-
-const PROVIDERS = [{ value: "Kaapi", label: "Kaapi" }];
+import { Button, Field, Modal } from "@/app/components/ui";
+import { APP_NAME } from "@/app/lib/constants";
 
 interface AddKeyModalProps {
   open: boolean;
   newKeyLabel: string;
   newKeyValue: string;
-  newKeyProvider: string;
   isValidating?: boolean;
   onLabelChange: (value: string) => void;
   onValueChange: (value: string) => void;
-  onProviderChange: (value: string) => void;
   onAddKey: () => void;
   onClose: () => void;
 }
@@ -21,11 +18,9 @@ export default function AddKeyModal({
   open,
   newKeyLabel,
   newKeyValue,
-  newKeyProvider,
   isValidating,
   onLabelChange,
   onValueChange,
-  onProviderChange,
   onAddKey,
   onClose,
 }: AddKeyModalProps) {
@@ -42,20 +37,16 @@ export default function AddKeyModal({
       <div className="px-6 pb-2">
         <p className="text-sm mb-5 text-text-secondary">
           Add a new API key to use in your evaluation workflows. Keys are stored
-          locally in your browser.
+          securely server-side and cannot be viewed again after they are added.
         </p>
 
         <div className="space-y-4">
-          <div>
-            <label className="block text-xs font-medium text-text-secondary mb-1">
-              Provider
-            </label>
-            <Select
-              value={newKeyProvider}
-              onChange={(e) => onProviderChange(e.target.value)}
-              options={PROVIDERS}
-            />
-          </div>
+          <Field
+            label="Provider"
+            value={APP_NAME}
+            onChange={() => {}}
+            disabled
+          />
 
           <Field
             label="Label"

--- a/app/components/keystore/KeysCard.tsx
+++ b/app/components/keystore/KeysCard.tsx
@@ -88,7 +88,7 @@ export default function KeysCard({
 
 function InlineNotice({ children }: { children: React.ReactNode }) {
   return (
-    <div className="rounded-md p-3 bg-status-warning-bg border border-status-warning-border">
+    <div className="rounded-full p-3 bg-status-warning-bg border border-status-warning-border">
       <div className="flex gap-2">
         <InfoIcon className="w-4 h-4 shrink-0 mt-0.5 text-status-warning-text" />
         <p className="text-xs text-status-warning-text">{children}</p>

--- a/app/components/keystore/KeysCard.tsx
+++ b/app/components/keystore/KeysCard.tsx
@@ -1,34 +1,17 @@
 "use client";
 
 import { Button } from "@/app/components/ui";
-import {
-  EyeIcon,
-  EyeOffIcon,
-  CopyIcon,
-  TrashIcon,
-  KeyIcon,
-  InfoIcon,
-  PlusIcon,
-  CheckLineIcon,
-} from "@/app/components/icons";
+import { TrashIcon, KeyIcon, InfoIcon, PlusIcon } from "@/app/components/icons";
 import { APIKey } from "@/app/lib/types/credentials";
 
 interface KeysCardProps {
   apiKeys: APIKey[];
-  visibleKeys: Set<string>;
-  copiedKeyId: string | null;
-  onToggleVisibility: (id: string) => void;
-  onCopy: (text: string, id: string) => void;
   onDelete: (id: string) => void;
   onAddNew: () => void;
 }
 
 export default function KeysCard({
   apiKeys,
-  visibleKeys,
-  copiedKeyId,
-  onToggleVisibility,
-  onCopy,
   onDelete,
   onAddNew,
 }: KeysCardProps) {
@@ -60,7 +43,8 @@ export default function KeysCard({
         <div className="space-y-4">
           <InlineNotice>
             Only one API key can be stored at a time. Delete this key to add a
-            different one.
+            different one. For your security, the key is stored server-side and
+            cannot be viewed again after it is added.
           </InlineNotice>
 
           {apiKeys.map((apiKey) => (
@@ -76,29 +60,15 @@ export default function KeysCard({
                     </h3>
                   </div>
                   <code className="block text-xs px-3 py-1.5 rounded-md font-mono break-all bg-bg-primary border border-border text-text-primary">
-                    {visibleKeys.has(apiKey.id) ? apiKey.key : "•".repeat(32)}
+                    {apiKey.masked ?? "•".repeat(32)}
                   </code>
-                  <p className="text-xs mt-2 text-text-secondary">
-                    Added {new Date(apiKey.createdAt).toLocaleDateString()}
-                  </p>
+                  {apiKey.createdAt && (
+                    <p className="text-xs mt-2 text-text-secondary">
+                      Added {new Date(apiKey.createdAt).toLocaleDateString()}
+                    </p>
+                  )}
                 </div>
                 <div className="flex items-center gap-1.5 shrink-0">
-                  <IconButton
-                    onClick={() => onToggleVisibility(apiKey.id)}
-                    title={visibleKeys.has(apiKey.id) ? "Hide" : "Show"}
-                  >
-                    {visibleKeys.has(apiKey.id) ? <EyeOffIcon /> : <EyeIcon />}
-                  </IconButton>
-                  <IconButton
-                    onClick={() => onCopy(apiKey.key, apiKey.id)}
-                    title={copiedKeyId === apiKey.id ? "Copied" : "Copy"}
-                  >
-                    {copiedKeyId === apiKey.id ? (
-                      <CheckLineIcon className="w-4 h-4 text-status-success" />
-                    ) : (
-                      <CopyIcon className="w-4 h-4" />
-                    )}
-                  </IconButton>
                   <IconButton
                     onClick={() => onDelete(apiKey.id)}
                     tone="danger"

--- a/app/components/keystore/KeysCard.tsx
+++ b/app/components/keystore/KeysCard.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/app/components/ui";
 import { TrashIcon, KeyIcon, InfoIcon, PlusIcon } from "@/app/components/icons";
 import { APIKey } from "@/app/lib/types/credentials";
+import { APP_NAME } from "@/app/lib/constants";
 
 interface KeysCardProps {
   apiKeys: APIKey[];
@@ -43,8 +44,7 @@ export default function KeysCard({
         <div className="space-y-4">
           <InlineNotice>
             Only one API key can be stored at a time. Delete this key to add a
-            different one. For your security, the raw key is kept in an HttpOnly
-            cookie and cannot be viewed again after it is added.
+            different one.
           </InlineNotice>
 
           {apiKeys.map((apiKey) => (
@@ -53,7 +53,7 @@ export default function KeysCard({
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-2 flex-wrap">
                     <span className="text-xs font-medium px-2.5 py-0.5 rounded-full bg-accent-primary/10 text-accent-primary border border-accent-primary/20">
-                      {apiKey.provider}
+                      {APP_NAME}
                     </span>
                     <h3 className="text-sm font-semibold text-text-primary truncate">
                       {apiKey.label}

--- a/app/components/keystore/KeysCard.tsx
+++ b/app/components/keystore/KeysCard.tsx
@@ -43,8 +43,8 @@ export default function KeysCard({
         <div className="space-y-4">
           <InlineNotice>
             Only one API key can be stored at a time. Delete this key to add a
-            different one. For your security, the key is stored server-side and
-            cannot be viewed again after it is added.
+            different one. For your security, the raw key is kept in an HttpOnly
+            cookie and cannot be viewed again after it is added.
           </InlineNotice>
 
           {apiKeys.map((apiKey) => (

--- a/app/lib/apiClient.ts
+++ b/app/lib/apiClient.ts
@@ -1,7 +1,25 @@
 import { NextRequest } from "next/server";
-import { AUTH_EXPIRED_EVENT } from "@/app/lib/constants";
+import { AUTH_EXPIRED_EVENT, COOKIE_KEYS } from "@/app/lib/constants";
 
 const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:8000";
+
+function readCookieHeader(cookieHeader: string, name: string): string {
+  for (const part of cookieHeader.split(";")) {
+    const eq = part.indexOf("=");
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() === name) {
+      return decodeURIComponent(part.slice(eq + 1).trim());
+    }
+  }
+  return "";
+}
+
+export function getRequestApiKey(request: NextRequest | Request): string {
+  const header = request.headers.get("X-API-KEY");
+  if (header) return header;
+  const cookieHeader = request.headers.get("Cookie") || "";
+  return readCookieHeader(cookieHeader, COOKIE_KEYS.API_KEY);
+}
 export type UploadPhase = "uploading" | "processing" | "done";
 type ApiClientOptions<TResponseType extends "json" | "raw" = "json"> =
   RequestInit & { responseType?: TResponseType };
@@ -30,7 +48,7 @@ export async function apiClient<
   options: ApiClientOptions<TResponseType> = {} as ApiClientOptions<TResponseType>,
 ): Promise<ApiClientResponse<TData, TResponseType>> {
   const { responseType = "json", ...requestOptions } = options;
-  const apiKey = request.headers.get("X-API-KEY") || "";
+  const apiKey = getRequestApiKey(request);
   const cookie = request.headers.get("Cookie") || "";
   const headers = new Headers(requestOptions.headers);
   if (
@@ -244,7 +262,7 @@ export async function apiFetch<T>(
     if (!(fetchOptions.body instanceof FormData)) {
       headers.set("Content-Type", "application/json");
     }
-    headers.set("X-API-KEY", apiKey);
+    if (apiKey) headers.set("X-API-KEY", apiKey);
     return headers;
   };
 

--- a/app/lib/authCookie.ts
+++ b/app/lib/authCookie.ts
@@ -1,9 +1,38 @@
 import type { NextResponse } from "next/server";
-import { COOKIE_KEYS, type FeatureFlagKey } from "@/app/lib/constants";
+import { AUTH_COOKIE_MAX_AGE, COOKIE_KEYS } from "@/app/lib/constants";
+import type { ApiKeyMeta } from "@/app/lib/types/credentials";
+import type { UserLike } from "@/app/lib/types/auth";
 
-interface UserLike {
-  is_superuser?: boolean;
-  features?: FeatureFlagKey[];
+export function setApiKeyCookies(
+  response: NextResponse,
+  key: string,
+  meta: ApiKeyMeta,
+): void {
+  const secure = process.env.NODE_ENV === "production" ? "; Secure" : "";
+  const attrs = `Path=/; Max-Age=${AUTH_COOKIE_MAX_AGE}; SameSite=Lax${secure}`;
+
+  response.headers.append(
+    "Set-Cookie",
+    `${COOKIE_KEYS.API_KEY}=${encodeURIComponent(key)}; ${attrs}; HttpOnly`,
+  );
+  response.headers.append(
+    "Set-Cookie",
+    `${COOKIE_KEYS.API_KEY_META}=${encodeURIComponent(JSON.stringify(meta))}; ${attrs}`,
+  );
+}
+
+export function clearApiKeyCookies(response: NextResponse): void {
+  const secure = process.env.NODE_ENV === "production" ? "; Secure" : "";
+  const attrs = `Path=/; Max-Age=0; SameSite=Lax${secure}`;
+
+  response.headers.append(
+    "Set-Cookie",
+    `${COOKIE_KEYS.API_KEY}=; ${attrs}; HttpOnly`,
+  );
+  response.headers.append(
+    "Set-Cookie",
+    `${COOKIE_KEYS.API_KEY_META}=; ${attrs}`,
+  );
 }
 
 /** Set the role cookie by appending a raw Set-Cookie header (won't overwrite existing cookies). */

--- a/app/lib/authCookie.ts
+++ b/app/lib/authCookie.ts
@@ -47,7 +47,7 @@ export function setRoleCookieFromBody(
 
   const value = user.is_superuser ? "superuser" : "user";
   const secure = process.env.NODE_ENV === "production" ? "; Secure" : "";
-  const cookie = `${COOKIE_KEYS.ROLE}=${value}; Path=/; Max-Age=${60 * 60 * 24 * 7}; SameSite=Lax${secure}`;
+  const cookie = `${COOKIE_KEYS.ROLE}=${value}; Path=/; Max-Age=${AUTH_COOKIE_MAX_AGE}; SameSite=Lax${secure}`;
 
   response.headers.append("Set-Cookie", cookie);
 }
@@ -71,7 +71,7 @@ export function setFeaturesCookieFromBody(
   const features = user.features.filter((f) => typeof f === "string");
   const value = encodeURIComponent(JSON.stringify(features));
   const secure = process.env.NODE_ENV === "production" ? "; Secure" : "";
-  const cookie = `${COOKIE_KEYS.FEATURES}=${value}; Path=/; Max-Age=${60 * 60 * 24 * 7}; SameSite=Lax${secure}`;
+  const cookie = `${COOKIE_KEYS.FEATURES}=${value}; Path=/; Max-Age=${AUTH_COOKIE_MAX_AGE}; SameSite=Lax${secure}`;
 
   response.headers.append("Set-Cookie", cookie);
 }

--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -16,7 +16,6 @@ export const FeatureFlag = {
 export type FeatureFlagKey = (typeof FeatureFlag)[keyof typeof FeatureFlag];
 
 export const STORAGE_KEYS = {
-  API_KEYS: "kaapi_api_keys",
   SESSION: "kaapi_session",
   CONFIGS_CACHE: "kaapi_configs_cache",
   COLLECTION_CACHE: "collection_job_cache",
@@ -28,7 +27,11 @@ export const STORAGE_KEYS = {
 export const COOKIE_KEYS = {
   ROLE: "kaapi_role",
   FEATURES: "kaapi_features",
+  API_KEY: "kaapi_api_key",
+  API_KEY_META: "kaapi_api_key_meta",
 } as const;
+
+export const AUTH_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 
 /** localStorage key for the config cache */
 export const CACHE_KEY = STORAGE_KEYS.CONFIGS_CACHE;

--- a/app/lib/context/AuthContext.tsx
+++ b/app/lib/context/AuthContext.tsx
@@ -17,11 +17,12 @@ import {
 import { apiFetch } from "@/app/lib/apiClient";
 import {
   AUTH_EXPIRED_EVENT,
+  COOKIE_KEYS,
   FEATURES_UPDATED_EVENT,
   STORAGE_KEYS,
 } from "@/app/lib/constants";
 import { useChatStore } from "@/app/lib/store/chat";
-import { clearAllStorage } from "@/app/lib/utils";
+import { clearAllStorage, readClientCookie } from "@/app/lib/utils";
 export type { User, GoogleProfile, Session } from "@/app/lib/types/auth";
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -32,11 +33,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [currentUser, setCurrentUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
 
-  // Initialize from localStorage after hydration
   useEffect(() => {
     try {
-      const storedKeys = localStorage.getItem(STORAGE_KEYS.API_KEYS);
-      if (storedKeys) setApiKeys(JSON.parse(storedKeys));
+      const rawMeta = readClientCookie(COOKIE_KEYS.API_KEY_META);
+      if (rawMeta) setApiKeys([JSON.parse(rawMeta) as APIKey]);
 
       const storedSession = localStorage.getItem(STORAGE_KEYS.SESSION);
       if (storedSession) {
@@ -53,7 +53,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   // Always fetch the latest user profile on hydration.
   useEffect(() => {
     if (!isHydrated) return;
-    const hasApiKey = !!apiKeys[0]?.key;
+    const hasApiKey = apiKeys.length > 0;
     const hasSession = !!session;
     if (!hasApiKey && !hasSession) return;
 
@@ -93,25 +93,32 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
   }, [apiKeys, session, isHydrated]);
 
-  const persist = useCallback((keys: APIKey[]) => {
-    setApiKeys(keys);
-    if (keys.length > 0) {
-      localStorage.setItem(STORAGE_KEYS.API_KEYS, JSON.stringify(keys));
-    } else {
-      localStorage.removeItem(STORAGE_KEYS.API_KEYS);
-    }
+  const addKey = useCallback(
+    async (input: { key: string; label: string; provider?: string }) => {
+      const res = await fetch("/api/apikeys", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify(input),
+      });
+      const body = (await res.json().catch(() => ({}))) as {
+        data?: APIKey;
+        error?: string;
+      };
+      if (!res.ok || !body.data) {
+        throw new Error(body.error || "Failed to add API key");
+      }
+      setApiKeys([body.data]);
+      window.dispatchEvent(new Event("kaapi-auth-changed"));
+    },
+    [],
+  );
+
+  const removeKey = useCallback(async () => {
+    await fetch("/api/apikeys", { method: "DELETE", credentials: "include" });
+    setApiKeys([]);
     window.dispatchEvent(new Event("kaapi-auth-changed"));
   }, []);
-
-  const addKey = useCallback(
-    (key: APIKey) => persist([...apiKeys, key]),
-    [apiKeys, persist],
-  );
-  const removeKey = useCallback(
-    (id: string) => persist(apiKeys.filter((k) => k.id !== id)),
-    [apiKeys, persist],
-  );
-  const setKeys = useCallback((keys: APIKey[]) => persist(keys), [persist]);
 
   const loginWithToken = useCallback(
     (accessToken: string, user?: User, googleProfile?: GoogleProfile) => {
@@ -143,7 +150,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     useChatStore.getState().reset();
     setApiKeys([]);
     window.dispatchEvent(new Event("kaapi-auth-changed"));
-    window.location.replace("/evaluations");
+    window.location.replace("/chat");
   }, []);
 
   // logout when both access + refresh tokens are expired
@@ -206,7 +213,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         hasFeature,
         addKey,
         removeKey,
-        setKeys,
         loginWithToken,
         logout,
       }}

--- a/app/lib/context/AuthContext.tsx
+++ b/app/lib/context/AuthContext.tsx
@@ -93,26 +93,23 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
   }, [apiKeys, session, isHydrated]);
 
-  const addKey = useCallback(
-    async (input: { key: string; label: string; provider?: string }) => {
-      const res = await fetch("/api/apikeys", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify(input),
-      });
-      const body = (await res.json().catch(() => ({}))) as {
-        data?: APIKey;
-        error?: string;
-      };
-      if (!res.ok || !body.data) {
-        throw new Error(body.error || "Failed to add API key");
-      }
-      setApiKeys([body.data]);
-      window.dispatchEvent(new Event("kaapi-auth-changed"));
-    },
-    [],
-  );
+  const addKey = useCallback(async (input: { key: string; label: string }) => {
+    const res = await fetch("/api/apikeys", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify(input),
+    });
+    const body = (await res.json().catch(() => ({}))) as {
+      data?: APIKey;
+      error?: string;
+    };
+    if (!res.ok || !body.data) {
+      throw new Error(body.error || "Failed to add API key");
+    }
+    setApiKeys([body.data]);
+    window.dispatchEvent(new Event("kaapi-auth-changed"));
+  }, []);
 
   const removeKey = useCallback(async () => {
     await fetch("/api/apikeys", { method: "DELETE", credentials: "include" });

--- a/app/lib/guardrailsClient.ts
+++ b/app/lib/guardrailsClient.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from "next/server";
+import { getRequestApiKey } from "@/app/lib/apiClient";
 
 const GUARDRAILS_URL = process.env.GUARDRAILS_URL || "http://localhost:8001";
 
@@ -22,7 +23,7 @@ export async function guardrailsClient(
   if (token) {
     headers.set("Authorization", `Bearer ${token}`);
   } else {
-    const apiKey = request.headers.get("X-API-KEY") || "";
+    const apiKey = getRequestApiKey(request);
     const cookie = request.headers.get("Cookie") || "";
     if (apiKey) headers.set("X-API-KEY", apiKey);
     if (cookie) headers.set("Cookie", cookie);

--- a/app/lib/types/auth.ts
+++ b/app/lib/types/auth.ts
@@ -1,4 +1,5 @@
 import { APIKey } from "./credentials";
+import type { FeatureFlagKey } from "@/app/lib/constants";
 
 export interface User {
   id: number;
@@ -7,6 +8,11 @@ export interface User {
   is_active: boolean;
   is_superuser: boolean;
   features?: string[];
+}
+
+export interface UserLike {
+  is_superuser?: boolean;
+  features?: FeatureFlagKey[];
 }
 
 export interface GoogleProfile {
@@ -71,9 +77,12 @@ export interface AuthContextValue {
   isAuthenticated: boolean;
   features: string[];
   hasFeature: (flag: string) => boolean;
-  addKey: (key: APIKey) => void;
-  removeKey: (id: string) => void;
-  setKeys: (keys: APIKey[]) => void;
+  addKey: (input: {
+    key: string;
+    label: string;
+    provider?: string;
+  }) => Promise<void>;
+  removeKey: (id?: string) => Promise<void>;
   loginWithToken: (
     accessToken: string,
     user?: User,

--- a/app/lib/types/auth.ts
+++ b/app/lib/types/auth.ts
@@ -77,11 +77,7 @@ export interface AuthContextValue {
   isAuthenticated: boolean;
   features: string[];
   hasFeature: (flag: string) => boolean;
-  addKey: (input: {
-    key: string;
-    label: string;
-    provider?: string;
-  }) => Promise<void>;
+  addKey: (input: { key: string; label: string }) => Promise<void>;
   removeKey: (id?: string) => Promise<void>;
   loginWithToken: (
     accessToken: string,

--- a/app/lib/types/credentials.ts
+++ b/app/lib/types/credentials.ts
@@ -106,7 +106,22 @@ export const PROVIDERS: ProviderDef[] = [
 export interface APIKey {
   id: string;
   label: string;
-  key: string;
   provider: string;
+  masked?: string;
   createdAt?: string;
+  key?: string;
+}
+
+export interface ApiKeyMeta {
+  id: string;
+  label: string;
+  provider: string;
+  masked: string;
+  createdAt: string;
+}
+
+export interface AddApiKeyRequest {
+  key?: string;
+  label?: string;
+  provider?: string;
 }

--- a/app/lib/types/credentials.ts
+++ b/app/lib/types/credentials.ts
@@ -106,7 +106,6 @@ export const PROVIDERS: ProviderDef[] = [
 export interface APIKey {
   id: string;
   label: string;
-  provider: string;
   masked?: string;
   createdAt?: string;
   key?: string;
@@ -115,7 +114,6 @@ export interface APIKey {
 export interface ApiKeyMeta {
   id: string;
   label: string;
-  provider: string;
   masked: string;
   createdAt: string;
 }
@@ -123,5 +121,4 @@ export interface ApiKeyMeta {
 export interface AddApiKeyRequest {
   key?: string;
   label?: string;
-  provider?: string;
 }

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -69,18 +69,14 @@ export const invalidateConfigCache = (): void => {
   clearConfigCache();
 };
 
-export const getApiKey = (): string | null => {
-  if (typeof window === "undefined") return null;
-  try {
-    const stored = localStorage.getItem(STORAGE_KEYS.API_KEYS);
-    if (stored) {
-      const keys = JSON.parse(stored);
-      return keys.length > 0 ? keys[0].key : null;
-    }
-  } catch (e) {
-    console.error("Failed to get API key:", e);
-  }
-  return null;
+export const readClientCookie = (name: string): string | undefined => {
+  if (typeof document === "undefined") return undefined;
+  const prefix = `${name}=`;
+  const entry = document.cookie
+    .split(";")
+    .map((part) => part.trim())
+    .find((part) => part.startsWith(prefix));
+  return entry ? decodeURIComponent(entry.slice(prefix.length)) : undefined;
 };
 
 /**

--- a/middleware.ts
+++ b/middleware.ts
@@ -46,10 +46,9 @@ export function middleware(request: NextRequest) {
   );
   const isAuthenticated = role === "superuser" || role === "user";
   const isSuperuser = role === "superuser";
-  const hasApiKey = !!request.cookies.get(COOKIE_KEYS.API_KEY)?.value;
 
   if (GUEST_ONLY_ROUTES.has(pathname)) {
-    if (hasApiKey) {
+    if (isAuthenticated) {
       return NextResponse.redirect(new URL(HOME_ROUTE, request.url));
     }
     return NextResponse.next();

--- a/middleware.ts
+++ b/middleware.ts
@@ -46,9 +46,10 @@ export function middleware(request: NextRequest) {
   );
   const isAuthenticated = role === "superuser" || role === "user";
   const isSuperuser = role === "superuser";
+  const hasApiKey = !!request.cookies.get(COOKIE_KEYS.API_KEY)?.value;
 
   if (GUEST_ONLY_ROUTES.has(pathname)) {
-    if (isAuthenticated) {
+    if (hasApiKey) {
       return NextResponse.redirect(new URL(HOME_ROUTE, request.url));
     }
     return NextResponse.next();


### PR DESCRIPTION
## Issue

Closes https://github.com/ProjectTech4DevAI/kaapi-frontend/issues/224

## Summary
* Move API Key Token Storage from LocalStorage to Cookies.
* Improve security by utilizing cookies for token storage.
* Removed key visibility and copy controls from the keystore view for a cleaner experience.

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `npm run dev` and `npm run build` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested