### PR TITLE
feat(evals): Add run mode to API payload

### DIFF
--- a/app/(main)/evaluations/page.tsx
+++ b/app/(main)/evaluations/page.tsx
@@ -230,8 +230,8 @@ function SimplifiedEvalContent() {
         experiment_name: experimentName.trim(),
         config_id: selectedConfigId,
         config_version: selectedConfigVersion,
+        run_mode: runMode === "fast" ? "fast" : "batch",
       };
-      if (runMode === "fast") payload.run_mode = "fast";
 
       await apiFetch("/api/evaluations", apiKey, {
         method: "POST",


### PR DESCRIPTION
## Summary
* Previously, the backend default `run_mode` was `batch`, so the frontend didn’t send `run_mode` explicitly. We only sent `run_mode=fast` when overriding the default behavior.
- Now that the backend default has changed to `fast`,`batch` runs will no longer work unless the frontend explicitly sends `run_mode=batch`. This PR updates the frontend to send the appropriate `run_mode` when triggering batch evaluations.

## Checklist

Before submitting a pull request, please ensure that you mark these task.
- [x] Ran `npm run dev` and `npm run build` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Evaluation runs now consistently use the selected run mode, including batch evaluations.
  * Improved reliability by explicitly communicating the run mode for every evaluation request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->